### PR TITLE
use values from Cargo.toml for `--help` and `--version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+* use values from Cargo.toml for `--help` and `--version`
+
 ## [0.1.2] - 2018-02-18
 
 * add missing package metadata to fix `cargo publish`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "jokeyrhyme-dotfiles"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ include = [
   "LICENSE",
 ]
 license = "MIT"
-license-file = "LICENSE"
 
 [dependencies]
 clap = "2.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jokeyrhyme-dotfiles"
-description = "read my dotfiles repository and does stuff"
+description = "read my dotfiles repository and do stuff"
 version = "0.1.2"
 authors = ["Ron Waldon <jokeyrhyme@gmail.com>"]
 documentation = "https://github.com/jokeyrhyme/dotfiles-rs#readme"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles-rs [![Build Status](https://travis-ci.org/jokeyrhyme/dotfiles-rs.svg?branch=master)](https://travis-ci.org/jokeyrhyme/dotfiles-rs)
 
-read my dotfiles repository and does stuff
+read my dotfiles repository and do stuff
 
 ## Features
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,12 @@ mod utils {
 }
 
 fn main() {
-    let matches = App::new("jokeyrhyme-dotfiles")
+    let matches = App::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
-        .subcommand(SubCommand::with_name("sync"))
+        .about(env!("CARGO_PKG_DESCRIPTION"))
+        .subcommand(SubCommand::with_name("sync").about(
+            "install / update my settings on this computer",
+        ))
         .get_matches();
 
     if let Some(_matches) = matches.subcommand_matches("sync") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ mod utils {
 
 fn main() {
     let matches = App::new("jokeyrhyme-dotfiles")
-        .version("0.1.0")
+        .version(env!("CARGO_PKG_VERSION"))
         .subcommand(SubCommand::with_name("sync"))
         .get_matches();
 


### PR DESCRIPTION
### Changed

* use values from Cargo.toml for `--help` and `--version`