### PR TITLE
pkg: rust: sync: install desired crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+* `sync` now reads a list of crates from a TOML file and installs missing crates with `cargo install`
+
 * add `update` command
 
-* implement `update` to update Rust with `rustup`
+* `update` now updates Rust with `rustup`
 
-* implement `update` to update crates installed by `cargo install`
+* `update` now updates crates installed by `cargo install`
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,9 @@ version = "0.1.2"
 dependencies = [
  "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -65,6 +68,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "redox_syscall"
@@ -97,9 +105,51 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "termion"
@@ -129,8 +179,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -184,15 +247,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5be5347bde0c48cfd8c3fdc0766cdfe9d8a755ef84d620d6794c778c91de8b2b"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
+"checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"
+"checksum serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ba7591cfe93755e89eeecdbcc668885624829b020050e6aec99c2a03bd3fd0"
+"checksum serde_derive_internals 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e03f1c9530c3fb0a0a5c9b826bdd9246a5921ae995d75f512ac917fc4dd55b5"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ license = "MIT"
 [dependencies]
 clap = "2.30"
 regex = "0.2.6"
+serde = "1.0.27"
+serde_derive = "1.0.27"
+toml = "0.4.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,9 @@
 extern crate clap;
 extern crate regex;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate toml;
 
 use clap::{App, SubCommand};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ mod tasks;
 mod utils {
     pub mod env;
     pub mod fs;
-    pub mod strings;
 }
 
 fn main() {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,8 +1,6 @@
 use std;
 use std::path::Path;
 
-use utils;
-
 pub fn create_dir_all_or_panic(target: std::option::Option<&Path>) {
     let target = match target {
         Some(target) => target,
@@ -17,7 +15,7 @@ pub fn create_dir_all_or_panic(target: std::option::Option<&Path>) {
         Err(error) => {
             panic!(
                 "unable to create directories {}: {:?}",
-                utils::strings::unoption(target.to_str()),
+                target.to_str().unwrap_or("nil"),
                 error
             );
         }
@@ -36,13 +34,13 @@ pub fn delete_if_exists(path: &Path) {
     if attr.is_dir() {
         match std::fs::remove_dir_all(path) {
             Ok(_removed) => {
-                println!("deleted {}", utils::strings::unoption(path.to_str()));
+                println!("deleted {}", path.to_str().unwrap_or("nil"));
                 return;
             }
             Err(error) => {
                 println!(
                     "unable to recursively delete directory {}: {:?}",
-                    utils::strings::unoption(path.to_str()),
+                    path.to_str().unwrap_or("nil"),
                     error
                 );
                 return;
@@ -58,7 +56,7 @@ pub fn delete_if_exists(path: &Path) {
         Err(error) => {
             println!(
                 "unable to delete file {}: {:?}",
-                utils::strings::unoption(path.to_str()),
+                path.to_str().unwrap_or("nil"),
                 error
             );
             return;
@@ -72,7 +70,7 @@ pub fn symbolic_link(src: &Path, dest: &Path) {
         Err(error) => {
             println!(
                 "unable to access {}: {:?}",
-                utils::strings::unoption(src.to_str()),
+                src.to_str().unwrap_or("nil"),
                 error
             );
             return;
@@ -95,8 +93,8 @@ pub fn symbolic_link(src: &Path, dest: &Path) {
         Err(error) => {
             println!(
                 "unable to symlink {} to {}: {:?}",
-                utils::strings::unoption(dest.to_str()),
-                utils::strings::unoption(src.to_str()),
+                dest.to_str().unwrap_or("nil"),
+                src.to_str().unwrap_or("nil"),
                 error
             );
             return;
@@ -111,8 +109,8 @@ pub fn symbolic_link(src: &Path, dest: &Path) {
             Err(error) => {
                 println!(
                     "unable to symlink {} to {}: {:?}",
-                    utils::strings::unoption(dest.to_str()),
-                    utils::strings::unoption(src.to_str()),
+                    dest.to_str().unwrap_or("nil"),
+                    src.to_str().unwrap_or("nil"),
                     error
                 );
                 return;
@@ -127,8 +125,8 @@ pub fn symbolic_link(src: &Path, dest: &Path) {
         Err(error) => {
             println!(
                 "unable to symlink {} to {}: {:?}",
-                utils::strings::unoption(dest.to_str()),
-                utils::strings::unoption(src.to_str()),
+                dest.to_str().unwrap_or("nil"),
+                src.to_str().unwrap_or("nil"),
                 error
             );
             return;
@@ -138,7 +136,7 @@ pub fn symbolic_link(src: &Path, dest: &Path) {
     #[cfg(any(unix,windows))]
     println!(
         "symlinked {} to {}",
-        utils::strings::unoption(dest.to_str()),
-        utils::strings::unoption(src.to_str()),
+        dest.to_str().unwrap_or("nil"),
+        src.to_str().unwrap_or("nil"),
     );
 }

--- a/src/utils/strings.rs
+++ b/src/utils/strings.rs
@@ -1,8 +1,0 @@
-use std::option;
-
-pub fn unoption(s: option::Option<&str>) -> &str {
-    return match s {
-        Some(s) => s,
-        None => "nil",
-    };
-}


### PR DESCRIPTION
### Added

* `sync` now reads a list of crates from a TOML file and installs missing crates with `cargo install`
