### PR TITLE
pkg: rust: update and sync needed crate only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * use values from Cargo.toml for `--help` and `--version`
 
+
+### Fixed
+
+* `sync` now actually avoid installing desired crates that already exist
+
 ## [0.1.2] - 2018-02-18
 
 ### Changed


### PR DESCRIPTION
### Fixed

* `sync` now actually avoids installing desired crates that already exist

* `update` now actually avoids updated installed crates that are already latest
