### PR TITLE
pkg: vscode: link settings correctly on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* pkg: vscode: link settings in the correct macOS-specific place
+
 ## [0.3.1] - 2018-02-26
 
 ### Fixed

--- a/src/tasks/vscode.rs
+++ b/src/tasks/vscode.rs
@@ -28,7 +28,11 @@ pub fn sync() {
     src.push(Path::new(".dotfiles/config/vscode.json"));
 
     let mut dest = utils::env::home_dir();
-    dest.push(Path::new(".config/Code/User/settings.json"));
+    #[cfg(target_os = "macos")]
+    let settings_path = "Library/Application Support/Code/User/settings.json";
+    #[cfg(not(target_os = "macos"))]
+    let settings_path = ".config/Code/User/settings.json";
+    dest.push(Path::new(settings_path));
 
     utils::fs::symbolic_link_if_exists(&src, &dest);
 


### PR DESCRIPTION
### Fixed

* pkg: vscode: link settings in the correct macOS-specific place
