### PR TITLE
pkg: atom: fix `apm install` bug caused by accidental whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* pkg: atom: fix `apm install` bug caused by accidental whitespace
+
 ## [0.4.0] - 2018-03-03
 
 ### Added

--- a/src/tasks/atom.rs
+++ b/src/tasks/atom.rs
@@ -55,7 +55,7 @@ pub fn sync() {
 
     for ext in config.install {
         if !pkgs.contains(&ext) {
-            utils::process::command_spawn_wait(COMMAND, &["install", "--compatible", "--production", " --quiet", &ext])
+            utils::process::command_spawn_wait(COMMAND, &["install", "--compatible", "--production", "--quiet", &ext])
                 .expect(ERROR_MSG);
         }
     }

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -71,11 +71,19 @@ mod tests {
     #[test]
     fn command_spawn_wait_does_not_exist() {
         match command_spawn_wait("does_not_exist", &["nope"]) {
-            Ok(_status) => {
+            Ok(status) => {
+                #[cfg(not(windows))]
                 assert!(false);
+
+                #[cfg(windows)]
+                assert!(!status.success());
             }
             Err(_error) => {
+                #[cfg(not(windows))]
                 assert!(true);
+
+                #[cfg(windows)]
+                assert!(false);
             }
         }
     }


### PR DESCRIPTION
### Fixed

* pkg: atom: fix `apm install` bug caused by accidental whitespace