### PR TITLE
pkg: atom: `sync` can now disable packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* pkg: atom: `sync` can now disable packages listed in TOML
+
 ## [0.4.1] - 2018-03-04
 
 ### Fixed

--- a/src/tasks/atom.rs
+++ b/src/tasks/atom.rs
@@ -14,6 +14,7 @@ const COMMAND: &str = "apm";
 
 #[derive(Debug, Deserialize)]
 struct Config {
+    disable: Vec<String>,
     install: Vec<String>,
     uninstall: Vec<String>,
 }
@@ -59,6 +60,11 @@ pub fn sync() {
                 .expect(ERROR_MSG);
         }
     }
+
+    let mut disable_args = vec![String::from("disable")];
+    disable_args.extend(config.disable);
+
+    utils::process::command_spawn_wait(COMMAND, &disable_args).expect(ERROR_MSG);
 
     for ext in config.uninstall {
         if pkgs.contains(&ext) {


### PR DESCRIPTION
### Added

* pkg: atom: `sync` can now disable packages listed in TOML