### PR TITLE
pkg: vim: Windows: _vimrc instead of .vimrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* pkg: vim: Windows: _vimrc instead of .vimrc
+
 ## [0.6.0] - 2018-03-10
 
 ### Added

--- a/src/tasks/vim.rs
+++ b/src/tasks/vim.rs
@@ -18,7 +18,10 @@ pub fn sync() {
     // END: remove old vim configurations
 
     let src = utils::env::home_dir().join(Path::new(".dotfiles/config/vimrc"));
+    #[cfg(not(windows))]
     let vimrc = utils::env::home_dir().join(Path::new(".vimrc"));
+    #[cfg(windows)]
+    let vimrc = utils::env::home_dir().join(Path::new("_vimrc"));
     utils::fs::symbolic_link_if_exists(&src, &vimrc);
 
     fetch_vim_plug(true);


### PR DESCRIPTION
### Fixed

* pkg: vim: Windows: _vimrc instead of .vimrc