### PR TITLE
pkg: nodejs: ignore other copies of Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * os: Windows: replace `%PATH%` checks with static instructions
 
+* pkg: nodejs: ignore other copies of Node.js in `has_node()`
+
 ## [0.11.0] - 2018-04-26
 
 ### Added

--- a/src/utils/golang.rs
+++ b/src/utils/golang.rs
@@ -64,7 +64,7 @@ pub fn current_version() -> String {
     }
 }
 
-pub fn install_path() -> PathBuf {
+fn install_path() -> PathBuf {
     utils::env::home_dir().join(".local").join("go")
 }
 

--- a/src/utils/nodejs.rs
+++ b/src/utils/nodejs.rs
@@ -1,5 +1,6 @@
 use std;
 use std::env::consts::{ARCH, OS};
+use std::path::PathBuf;
 use std::string::String;
 
 use serde_json;
@@ -36,14 +37,12 @@ pub fn current_version() -> String {
 }
 
 pub fn has_node() -> bool {
-    match utils::process::command_output("node", &["--version"]) {
-        Ok(output) => {
-            return output.status.success();
-        }
-        Err(_error) => {
-            return false; // npx probably not installed
-        }
-    }
+    #[cfg(windows)]
+    let exe_path = install_path().join("bin").join("node.exe");
+    #[cfg(not(windows))]
+    let exe_path = install_path().join("bin").join("node");
+
+    exe_path.is_file()
 }
 
 pub fn has_npm() -> bool {
@@ -74,9 +73,13 @@ pub fn has_yarn() -> bool {
             return output.status.success();
         }
         Err(_error) => {
-            return false; // npx probably not installed
+            return false; // yarn probably not installed
         }
     }
+}
+
+fn install_path() -> PathBuf {
+    utils::env::home_dir().join(".local").join("node")
 }
 
 pub fn latest_version() -> String {


### PR DESCRIPTION
### Fixed

* pkg: nodejs: ignore other copies of Node.js in `has_node()`