### PR TITLE
HTTP request logs no longer include QSA / fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * pkg: vscode: macOS: added a work-around to fix app auto-update
 
+### Changed
+
+* HTTP request logs no longer include query string or fragment
+
 ### Fixed
 
 * os: Windows: replace `%PATH%` checks with static instructions
-
-* pkg: nodejs: ignore other copies of Node.js in `has_node()`
 
 ## [0.11.0] - 2018-04-26
 

--- a/src/utils/github.rs
+++ b/src/utils/github.rs
@@ -145,14 +145,14 @@ pub fn fetch_tags<T: AsRef<str>>(owner: &T, repo: &T) -> io::Result<Vec<Tag>> {
     let tags: Vec<Tag> = match serde_json::from_str(&body) {
         Ok(t) => t,
         Err(error) => {
-            println!("cannot fetch GitHub tags");
+            println!("cannot fetch GitHub tags: {:?}", error);
             Vec::<Tag>::new()
         }
     };
     Ok(
         tags.into_iter()
             .map(|t| {
-                Tag{
+                Tag {
                     id: str::replace(&t.id, "refs/tags/", ""),
                     url: t.url,
                 }


### PR DESCRIPTION
### Changed

* HTTP request logs no longer include query string or fragment
