### PR TITLE
golang: favourites, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - golang: `sync`/`update` grab favourite packages listed in TOML
 
+- golang: `sync`/`update` grab linters with [gometalinter](https://github.com/alecthomas/gometalinter)
+
 ### Changed
 
 - drop "pkg: " prefix from log output, etc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - golang: `sync`/`update` grab favourite packages listed in TOML
 
+### Changed
+
+- drop "pkg: " prefix from log output, etc
+
 ### Fixed
 
 - fix `.unwrap()` panic when HTTP requests time out
@@ -19,33 +23,33 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- pkg: tmux: `sync` installs [tpm](https://github.com/tmux-plugins/tpm)
+- tmux: `sync` installs [tpm](https://github.com/tmux-plugins/tpm)
 
 ### Fixed
 
-- pkg: git: fix installation of yarn merge driver
+- git: fix installation of yarn merge driver
 
 ## [0.13.0] - 2018-05-17
 
 ### Added
 
-- pkg: ssh: `sync` merges ~/.dotfiles/config/ssh into ~/.ssh/config
+- ssh: `sync` merges ~/.dotfiles/config/ssh into ~/.ssh/config
 
-- pkg: ssh: `sync` blacklists weak ciphers / algorithms
+- ssh: `sync` blacklists weak ciphers / algorithms
 
 ### Fixed
 
-- pkg: ssh: deterministic Host and Match section order
+- ssh: deterministic Host and Match section order
 
-- pkg: vscode: fix copy-pasta with macOS xattr fix
+- vscode: fix copy-pasta with macOS xattr fix
 
 ## [0.12.0] - 2018-05-10
 
 ### Added
 
-- pkg: [golang](https://golang.org/): `sync` and `update`
+- [golang](https://golang.org/): `sync` and `update`
 
-- pkg: vscode: macOS: added a work-around to fix app auto-update
+- vscode: macOS: added a work-around to fix app auto-update
 
 ### Changed
 
@@ -61,15 +65,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- pkg: [jq](https://github.com/stedolan/jq): `sync` and `update`
+- [jq](https://github.com/stedolan/jq): `sync` and `update`
 
 ### Fixed
 
-- pkg: nodejs: macOS: fix OS mappings
+- nodejs: macOS: fix OS mappings
 
-- pkg: nodejs: Windows: handle path differences
+- nodejs: Windows: handle path differences
 
-- pkg: nodejs: install/update NPM packages after updating Node.js
+- nodejs: install/update NPM packages after updating Node.js
 
 - slightly better error handling
 
@@ -77,21 +81,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- pkg: [nodejs](https://nodejs.org): `sync` and `update` install the latest version of Node.js on Linux, macOS, and Windows
+- [nodejs](https://nodejs.org): `sync` and `update` install the latest version of Node.js on Linux, macOS, and Windows
 
-- pkg: nodejs: `sync` enables metrics in `npm`
+- nodejs: `sync` enables metrics in `npm`
 
 ### Fixed
 
 - Windows: fix the build again :S
 
-- pkg: dep,shfmt,skaffold,yq: Windows needs .exe extension
+- dep,shfmt,skaffold,yq: Windows needs .exe extension
 
 ## [0.9.0] - 2018-04-19
 
 ### Added
 
-- pkg: [dep](https://github.com/golang/dep): `sync` (into ~/.local/bin) and `update`
+- [dep](https://github.com/golang/dep): `sync` (into ~/.local/bin) and `update`
 
 ### Fixed
 
@@ -101,7 +105,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- pkg: [yq](https://github.com/mikefarah/yq): `sync` (into ~/.local/bin) and `update`
+- [yq](https://github.com/mikefarah/yq): `sync` (into ~/.local/bin) and `update`
 
 ### Changed
 
@@ -111,7 +115,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - ensure target directory exists when downloading files
 
-- pkg: shfmt,skaffold: fix macOS asset detection
+- shfmt,skaffold: fix macOS asset detection
 
 ## [0.7.0] - 2018-04-11
 
@@ -119,33 +123,33 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Windows: ensure ~/bin exists in PATH
 
-- pkg: [shfmt](https://github.com/mvdan/sh): `sync` (into ~/bin) and `update`
+- [shfmt](https://github.com/mvdan/sh): `sync` (into ~/bin) and `update`
 
-- pkg: [skaffold](https://github.com/GoogleCloudPlatform/skaffold): `sync` (into ~/bin) and `update`
+- [skaffold](https://github.com/GoogleCloudPlatform/skaffold): `sync` (into ~/bin) and `update`
 
-- pkg: tmux: `sync` and `update` install, clean, and update [tpm plugins](https://github.com/tmux-plugins/tpm/blob/master/docs/managing_plugins_via_cmd_line.md)
+- tmux: `sync` and `update` install, clean, and update [tpm plugins](https://github.com/tmux-plugins/tpm/blob/master/docs/managing_plugins_via_cmd_line.md)
 
 ## [0.6.1] - 2018-03-14
 
 ### Fixed
 
-- pkg: nodejs: properly identify installed packages
+- nodejs: properly identify installed packages
 
-- pkg: vim: Windows: \_vimrc instead of .vimrc
+- vim: Windows: \_vimrc instead of .vimrc
 
 ## [0.6.0] - 2018-03-10
 
 ### Added
 
-- pkg: git: configure [npm-merge-driver](https://www.npmjs.com/package/npm-merge-driver) when possible
+- git: configure [npm-merge-driver](https://www.npmjs.com/package/npm-merge-driver) when possible
 
-- pkg: nodejs: `sync` will (un)install `npm` packages as listed in TOML
+- nodejs: `sync` will (un)install `npm` packages as listed in TOML
 
-- pkg: nodejs: `update` will update `npm` and global packages
+- nodejs: `update` will update `npm` and global packages
 
-- pkg: vim: `sync` will (un)install vim-plug and symlink .vimrc
+- vim: `sync` will (un)install vim-plug and symlink .vimrc
 
-- pkg: vim: `update` will update vim-plug and plugins
+- vim: `update` will update vim-plug and plugins
 
 ### Fixed
 
@@ -155,35 +159,35 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- pkg: atom: `sync` can now disable packages listed in TOML
+- atom: `sync` can now disable packages listed in TOML
 
-- pkg: dotfiles: `sync` calls `git pull` in ~/.dotfiles
+- dotfiles: `sync` calls `git pull` in ~/.dotfiles
 
 ## [0.4.1] - 2018-03-04
 
 ### Fixed
 
-- pkg: atom: fix `apm install` bug caused by accidental whitespace
+- atom: fix `apm install` bug caused by accidental whitespace
 
 ## [0.4.0] - 2018-03-03
 
 ### Added
 
-- pkg: atom: implement `sync` and `update`
+- atom: implement `sync` and `update`
 
 ### Fixed
 
-- pkg: vscode: `update` now works on Windows
+- vscode: `update` now works on Windows
 
-- pkg: vscode: link settings in the correct macOS-specific place
+- vscode: link settings in the correct macOS-specific place
 
-- pkg: vscode: use the correct settings path on Windows
+- vscode: use the correct settings path on Windows
 
 ## [0.3.1] - 2018-02-26
 
 ### Fixed
 
-- pkg: vscode: check for "code.cmd" on Windows
+- vscode: check for "code.cmd" on Windows
 
 ## [0.3.0] - 2018-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - drop "pkg: " prefix from log output, etc
 
+- less verbose archive extraction
+
 ### Fixed
 
 - fix `.unwrap()` panic when HTTP requests time out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- golang: `sync` delete `dep` installed by `go get ...`
+
 - golang: `sync`/`update` grab favourite packages listed in TOML
 
 - golang: `sync`/`update` grab linters with [gometalinter](https://github.com/alecthomas/gometalinter)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- golang: `sync`/`update` grab favourite packages listed in TOML
+
 ### Fixed
 
 - fix `.unwrap()` panic when HTTP requests time out

--- a/src/tasks/alacritty.rs
+++ b/src/tasks/alacritty.rs
@@ -1,7 +1,7 @@
 use utils;
 
 pub fn sync() {
-    println!("pkg: alacritty: syncing ...");
+    println!("alacritty: syncing ...");
 
     let src = utils::env::home_dir().join(".dotfiles/config/alacritty.yml");
     let dest = utils::env::home_dir().join(".config/alacritty/alacritty.yml");

--- a/src/tasks/atom.rs
+++ b/src/tasks/atom.rs
@@ -20,7 +20,7 @@ pub fn sync() {
         return;
     }
 
-    println!("pkg: atom: syncing ...");
+    println!("atom: syncing ...");
 
     // TODO: synchronise Atom settings
 
@@ -29,7 +29,7 @@ pub fn sync() {
     let contents = match fs::read_to_string(&cfg_path) {
         Ok(s) => s,
         Err(error) => {
-            println!("pkg: atom: ignoring config: {}", error);
+            println!("atom: ignoring config: {}", error);
             return;
         }
     };
@@ -65,7 +65,7 @@ pub fn update() {
         return;
     }
 
-    println!("pkg: atom: updating ...");
+    println!("atom: updating ...");
 
     utils::process::command_spawn_wait(COMMAND, &["upgrade", "--confirm", "false"])
         .expect(ERROR_MSG);

--- a/src/tasks/dep.rs
+++ b/src/tasks/dep.rs
@@ -7,13 +7,13 @@ use utils::golang::{arch, os};
 const ERROR_MSG: &str = "error: dep";
 
 pub fn sync() {
-    println!("pkg: dep: syncing ...");
+    println!("dep: syncing ...");
 
     if !is_installed() {
         let release = match utils::github::latest_release(&"golang", &"dep") {
             Ok(r) => r,
             Err(error) => {
-                println!("error: pkg: dep: {}", error);
+                println!("error: dep: {}", error);
                 return;
             }
         };
@@ -26,7 +26,7 @@ pub fn update() {
         return;
     }
 
-    println!("pkg: dep: updating ...");
+    println!("dep: updating ...");
 
     let current = installed_version();
     match utils::github::release_versus_current(
@@ -43,12 +43,12 @@ fn install_release_asset(release: Release) {
     let asset = match latest_asset(&release) {
         Some(a) => a,
         None => {
-            println!("pkg: dep: no asset matches OS and ARCH");
+            println!("dep: no asset matches OS and ARCH");
             return;
         }
     };
 
-    println!("pkg: dep: installing ...");
+    println!("dep: installing ...");
 
     #[cfg(windows)]
     let bin_path = utils::env::home_dir().join(".local/bin/dep.exe");

--- a/src/tasks/dotfiles.rs
+++ b/src/tasks/dotfiles.rs
@@ -1,7 +1,7 @@
 use utils;
 
 pub fn sync() {
-    println!("pkg: dotfiles: syncing ...");
+    println!("dotfiles: syncing ...");
 
     let target = utils::env::home_dir().join(".dotfiles");
 

--- a/src/tasks/git.rs
+++ b/src/tasks/git.rs
@@ -19,7 +19,7 @@ pub fn sync() {
         return;
     }
 
-    println!("pkg: git: syncing ...");
+    println!("git: syncing ...");
 
     // https://www.npmjs.com/package/npm-merge-driver
     utils::process::command_spawn_wait("npx", &["-q", "npm-merge-driver", "install", "--global"])

--- a/src/tasks/golang.rs
+++ b/src/tasks/golang.rs
@@ -2,6 +2,7 @@ use std::fs;
 
 use mktemp;
 use toml;
+use which;
 
 use utils::{self, golang::{arch, os}};
 
@@ -52,6 +53,18 @@ pub fn sync () {
             }
         };
     }
+
+    match which::which("gometalinter") {
+        Ok(_) => {
+            match utils::process::command_spawn_wait("gometalinter", &["--install"]) {
+                Ok(_status) => {}
+                Err(error) => {
+                    println!("warning: golang: unable to install linters: {}", error)
+                }
+            };
+        }
+        Err(_) => {}
+    };
 }
 
 pub fn update () {
@@ -91,6 +104,18 @@ pub fn update () {
         Err(error) => {
             println!("warning: golang: unable to update packages: {}", error)
         }
+    };
+
+    match which::which("gometalinter") {
+        Ok(_) => {
+            match utils::process::command_spawn_wait("gometalinter", &["--install", "--force"]) {
+                Ok(_status) => {}
+                Err(error) => {
+                    println!("warning: golang: unable to update linters: {}", error)
+                }
+            };
+        }
+        Err(_) => {}
     };
 }
 

--- a/src/tasks/golang.rs
+++ b/src/tasks/golang.rs
@@ -19,13 +19,13 @@ impl Config {
 }
 
 pub fn sync () {
-    println!("pkg: golang: syncing ...");
+    println!("golang: syncing ...");
 
     if !utils::golang::is_installed() {
         let latest_version = match utils::golang::latest_version() {
             Ok(v) => v,
             Err(error) => {
-                println!("error: pkg: golang: unable to check for updates: {:?}", error);
+                println!("error: golang: unable to check for updates: {:?}", error);
                 return;
             }
         };
@@ -33,7 +33,7 @@ pub fn sync () {
         match install_golang(&latest_version) {
             Ok(_) => {}
             Err(error) => {
-                println!("error: pkg: golang: unable to install: {:?}", error);
+                println!("error: golang: unable to install: {:?}", error);
                 return;
             }
         };
@@ -48,7 +48,7 @@ pub fn sync () {
         match utils::process::command_spawn_wait("go", &install_args) {
             Ok(_status) => {}
             Err(error) => {
-                println!("warning: pkg: golang: unable to install packages: {}", error)
+                println!("warning: golang: unable to install packages: {}", error)
             }
         };
     }
@@ -59,13 +59,13 @@ pub fn update () {
         return;
     }
 
-    println!("pkg: golang: updating ...");
+    println!("golang: updating ...");
 
     let current_version = utils::golang::current_version();
     let latest_version = match utils::golang::latest_version() {
         Ok(v) => v,
         Err(error) => {
-            println!("error: pkg: golang: unable to check for updates: {:?}", error);
+            println!("error: golang: unable to check for updates: {:?}", error);
             return;
         }
     };
@@ -75,7 +75,7 @@ pub fn update () {
         match install_golang(&latest_version) {
             Ok(_) => {}
             Err(error) => {
-                println!("error: pkg: golang: unable to install: {:?}", error);
+                println!("error: golang: unable to install: {:?}", error);
                 return;
             }
         };
@@ -89,13 +89,13 @@ pub fn update () {
     match utils::process::command_spawn_wait("go", &install_args) {
         Ok(_status) => {}
         Err(error) => {
-            println!("warning: pkg: golang: unable to update packages: {}", error)
+            println!("warning: golang: unable to update packages: {}", error)
         }
     };
 }
 
 fn install_golang(version: &str) -> Result<(), utils::golang::GolangError> {
-    println!("pkg: golang: installing {} ...", &version);
+    println!("golang: installing {} ...", &version);
 
     let temp_path;
     {
@@ -131,7 +131,7 @@ fn read_config() -> Config {
     let contents = match fs::read_to_string(&cfg_path) {
         Ok(s) => s,
         Err(error) => {
-            println!("pkg: golang: ignoring config: {}", error);
+            println!("golang: ignoring config: {}", error);
             return Config::new();
         }
     };
@@ -139,7 +139,7 @@ fn read_config() -> Config {
     match toml::from_str(&contents) {
         Ok(c) => c,
         Err(error) => {
-            println!("warning: pkg: golang: unable to parse {}, {}", &cfg_path.display(), error);
+            println!("warning: golang: unable to parse {}, {}", &cfg_path.display(), error);
             Config::new()
         }
     }

--- a/src/tasks/golang.rs
+++ b/src/tasks/golang.rs
@@ -1,29 +1,57 @@
+use std::fs;
+
 use mktemp;
+use toml;
 
 use utils::{self, golang::{arch, os}};
 
-pub fn sync () {
-    if utils::golang::is_installed() {
-        return;
-    }
+#[derive(Debug, Deserialize)]
+struct Config {
+    install: Vec<String>,
+}
 
+impl Config {
+    fn new() -> Config {
+        Config {
+            install: Vec::<String>::new(),
+        }
+    }
+}
+
+pub fn sync () {
     println!("pkg: golang: syncing ...");
 
-    let latest_version = match utils::golang::latest_version() {
-        Ok(v) => v,
-        Err(error) => {
-            println!("error: pkg: golang: unable to check for updates: {:?}", error);
-            return;
-        }
-    };
+    if !utils::golang::is_installed() {
+        let latest_version = match utils::golang::latest_version() {
+            Ok(v) => v,
+            Err(error) => {
+                println!("error: pkg: golang: unable to check for updates: {:?}", error);
+                return;
+            }
+        };
 
-    match install_golang(&latest_version) {
-        Ok(_) => {}
-        Err(error) => {
-            println!("error: pkg: golang: unable to install: {:?}", error);
-            return;
-        }
-    };
+        match install_golang(&latest_version) {
+            Ok(_) => {}
+            Err(error) => {
+                println!("error: pkg: golang: unable to install: {:?}", error);
+                return;
+            }
+        };
+    }
+
+    if utils::golang::is_installed() {
+        let config = read_config();
+
+        let mut install_args = vec![String::from("get"), String::from("-v")];
+        install_args.extend(config.install);
+
+        match utils::process::command_spawn_wait("go", &install_args) {
+            Ok(_status) => {}
+            Err(error) => {
+                println!("warning: pkg: golang: unable to install packages: {}", error)
+            }
+        };
+    }
 }
 
 pub fn update () {
@@ -52,6 +80,18 @@ pub fn update () {
             }
         };
     }
+
+    let config = read_config();
+
+    let mut install_args = vec![String::from("get"), String::from("-u"), String::from("-v")];
+    install_args.extend(config.install);
+
+    match utils::process::command_spawn_wait("go", &install_args) {
+        Ok(_status) => {}
+        Err(error) => {
+            println!("warning: pkg: golang: unable to update packages: {}", error)
+        }
+    };
 }
 
 fn install_golang(version: &str) -> Result<(), utils::golang::GolangError> {
@@ -83,4 +123,24 @@ fn install_golang(version: &str) -> Result<(), utils::golang::GolangError> {
     utils::fs::delete_if_exists(&temp_path);
 
     Ok(())
+}
+
+fn read_config() -> Config {
+    let cfg_path = utils::env::home_dir().join(".dotfiles/config/golang.toml");
+
+    let contents = match fs::read_to_string(&cfg_path) {
+        Ok(s) => s,
+        Err(error) => {
+            println!("pkg: golang: ignoring config: {}", error);
+            return Config::new();
+        }
+    };
+
+    match toml::from_str(&contents) {
+        Ok(c) => c,
+        Err(error) => {
+            println!("warning: pkg: golang: unable to parse {}, {}", &cfg_path.display(), error);
+            Config::new()
+        }
+    }
 }

--- a/src/tasks/golang.rs
+++ b/src/tasks/golang.rs
@@ -22,6 +22,15 @@ impl Config {
 pub fn sync () {
     println!("golang: syncing ...");
 
+    let home_dir = utils::env::home_dir();
+
+    // uninstall `dep` installed by `go get -u ...`
+    // we install `dep` via GitHub Release instead as recommended
+    utils::fs::delete_if_exists(&home_dir.join("go").join("bin").join("dep"));
+    utils::fs::delete_if_exists(&home_dir.join("go").join("bin").join("dep.exe"));
+    utils::fs::delete_if_exists(&home_dir.join("go").join("pkg").join("src").join("github.com").join("golang").join("dep"));
+    utils::fs::delete_if_exists(&home_dir.join("go").join("src").join("src").join("github.com").join("golang").join("dep"));
+
     if !utils::golang::is_installed() {
         let latest_version = match utils::golang::latest_version() {
             Ok(v) => v,

--- a/src/tasks/hyper.rs
+++ b/src/tasks/hyper.rs
@@ -1,7 +1,7 @@
 use utils;
 
 pub fn sync() {
-    println!("pkg: hyper: syncing ...");
+    println!("hyper: syncing ...");
 
     let src = utils::env::home_dir().join(".dotfiles/config/hyper.js");
     let dest = utils::env::home_dir().join(".hyper.js");

--- a/src/tasks/jq.rs
+++ b/src/tasks/jq.rs
@@ -5,13 +5,13 @@ use utils;
 use utils::github::{Asset, Release};
 
 pub fn sync() {
-    println!("pkg: jq: syncing ...");
+    println!("jq: syncing ...");
 
     if !is_installed() {
         let release = match utils::github::latest_release(&"stedolan", &"jq") {
             Ok(r) => r,
             Err(error) => {
-                println!("error: pkg: jq: {}", error);
+                println!("error: jq: {}", error);
                 return;
             }
         };
@@ -24,7 +24,7 @@ pub fn update() {
         return;
     }
 
-    println!("pkg: jq: updating ...");
+    println!("jq: updating ...");
 
     match utils::process::command_output("jq", &["--version"]) {
         Ok(output) => {
@@ -43,12 +43,12 @@ fn install_release_asset(release: Release) {
     let asset = match latest_asset(&release) {
         Some(a) => a,
         None => {
-            println!("pkg: jq: no asset matches OS and ARCH");
+            println!("jq: no asset matches OS and ARCH");
             return;
         }
     };
 
-    println!("pkg: jq: installing ...");
+    println!("jq: installing ...");
 
     #[cfg(windows)]
     let bin_path = utils::env::home_dir().join(".local/bin/jq.exe");

--- a/src/tasks/nodejs.rs
+++ b/src/tasks/nodejs.rs
@@ -32,14 +32,14 @@ impl Config {
 }
 
 pub fn sync() {
-    println!("pkg: nodejs: syncing ...");
+    println!("nodejs: syncing ...");
 
     if !utils::nodejs::has_node() {
         let latest = utils::nodejs::latest_version();
         match install_nodejs(&latest) {
             Ok(()) => {}
             Err(error) => {
-                println!("error: pkg: nodejs: unable to install Node.js: {:?}", error)
+                println!("error: nodejs: unable to install Node.js: {:?}", error)
             }
         };
     }
@@ -53,7 +53,7 @@ pub fn update() {
         return;
     }
 
-    println!("pkg: nodejs: updating ...");
+    println!("nodejs: updating ...");
 
     let current = utils::nodejs::current_version();
     let latest = utils::nodejs::latest_version();
@@ -63,7 +63,7 @@ pub fn update() {
         match install_nodejs(&latest) {
             Ok(()) => {}
             Err(error) => {
-                println!("error: pkg: nodejs: unable to install Node.js: {:?}", error)
+                println!("error: nodejs: unable to install Node.js: {:?}", error)
             }
         };
         sync_npm_packages();
@@ -83,7 +83,7 @@ fn configure_npm() {
     match utils::process::command_spawn_wait("npm", &["config", "set", "send-metric", "true"]) {
         Ok(_status) => {}
         Err(error) => {
-            println!("warning: pkg: nodejs: unable to enable npm metrics: {}", error);
+            println!("warning: nodejs: unable to enable npm metrics: {}", error);
         }
     }
 }
@@ -160,7 +160,7 @@ fn read_config() -> Config {
     let contents = match fs::read_to_string(&cfg_path) {
         Ok(s) => s,
         Err(error) => {
-            println!("pkg: nodejs: ignoring config: {}", error);
+            println!("nodejs: ignoring config: {}", error);
             return Config::new();
         }
     };
@@ -168,7 +168,7 @@ fn read_config() -> Config {
     match toml::from_str(&contents) {
         Ok(c) => c,
         Err(error) => {
-            println!("warning: pkg: nodejs: unable to parse {}, {}", &cfg_path.display(), error);
+            println!("warning: nodejs: unable to parse {}, {}", &cfg_path.display(), error);
             Config::new()
         }
     }
@@ -199,7 +199,7 @@ fn sync_npm_packages() {
         match utils::process::command_spawn_wait("node", &[npm_cli_path_str, "install", "--global", "npm"]) {
             Ok(_status) => {}
             Err(error) => {
-                println!("warning: pkg: nodejs: unable to bootstrap npm: {}", error);
+                println!("warning: nodejs: unable to bootstrap npm: {}", error);
             }
         };
     }
@@ -228,7 +228,7 @@ fn sync_npm_packages() {
     match utils::process::command_spawn_wait("npm", &install_args) {
         Ok(_status) => {}
         Err(error) => {
-            println!("warning: pkg: nodejs: unable to install missing npm packages: {}", error)
+            println!("warning: nodejs: unable to install missing npm packages: {}", error)
         }
     };
 
@@ -253,7 +253,7 @@ fn sync_npm_packages() {
     match utils::process::command_spawn_wait("npm", &uninstall_args) {
         Ok(_status) => {}
         Err(error) => {
-            println!("warning: pkg: nodejs: unable to uninstall unused npm packages: {}", error)
+            println!("warning: nodejs: unable to uninstall unused npm packages: {}", error)
         }
     };
 }

--- a/src/tasks/psql.rs
+++ b/src/tasks/psql.rs
@@ -5,7 +5,7 @@ pub fn sync() {
         return;
     }
 
-    println!("pkg: psql: syncing ...");
+    println!("psql: syncing ...");
 
     let src = utils::env::home_dir().join(".dotfiles/config/psqlrc");
     let dest = utils::env::home_dir().join(".psqlrc");

--- a/src/tasks/rust.rs
+++ b/src/tasks/rust.rs
@@ -18,14 +18,14 @@ pub fn sync() {
         return;
     }
 
-    println!("pkg: rust: syncing ...");
+    println!("rust: syncing ...");
 
     let cfg_path = utils::env::home_dir().join(".dotfiles/config/rust.toml");
 
     let contents = match fs::read_to_string(&cfg_path) {
         Ok(s) => s,
         Err(error) => {
-            println!("pkg: rust: ignoring config: {}", error);
+            println!("rust: ignoring config: {}", error);
             return;
         }
     };
@@ -60,7 +60,7 @@ pub fn update() {
         return;
     }
 
-    println!("pkg: rust: updating ...");
+    println!("rust: updating ...");
 
     utils::process::command_spawn_wait("rustup", &["override", "set", "stable"]).expect(ERROR_MSG);
 

--- a/src/tasks/shfmt.rs
+++ b/src/tasks/shfmt.rs
@@ -5,13 +5,13 @@ use utils::github::{Asset, Release};
 use utils::golang::{arch, os};
 
 pub fn sync() {
-    println!("pkg: shfmt: syncing ...");
+    println!("shfmt: syncing ...");
 
     if !is_installed() {
         let release = match utils::github::latest_release(&"mvdan", &"sh") {
             Ok(r) => r,
             Err(error) => {
-                println!("error: pkg: shfmt: {}", error);
+                println!("error: shfmt: {}", error);
                 return;
             }
         };
@@ -24,7 +24,7 @@ pub fn update() {
         return;
     }
 
-    println!("pkg: shfmt: updating ...");
+    println!("shfmt: updating ...");
 
     match utils::process::command_output("shfmt", &["--version"]) {
         Ok(output) => {
@@ -43,12 +43,12 @@ fn install_release_asset(release: Release) {
     let asset = match latest_asset(&release) {
         Some(a) => a,
         None => {
-            println!("pkg: shfmt: no asset matches OS and ARCH");
+            println!("shfmt: no asset matches OS and ARCH");
             return;
         }
     };
 
-    println!("pkg: shfmt: installing ...");
+    println!("shfmt: installing ...");
 
     #[cfg(windows)]
     let bin_path = utils::env::home_dir().join(".local/bin/shfmt.exe");

--- a/src/tasks/skaffold.rs
+++ b/src/tasks/skaffold.rs
@@ -5,13 +5,13 @@ use utils::github::{Asset, Release};
 use utils::golang::{arch, os};
 
 pub fn sync() {
-    println!("pkg: skaffold: syncing ...");
+    println!("skaffold: syncing ...");
 
     if !is_installed() {
         let release = match utils::github::latest_release(&"GoogleCloudPlatform", &"skaffold") {
             Ok(r) => r,
             Err(error) => {
-                println!("error: pkg: skaffold: {}", error);
+                println!("error: skaffold: {}", error);
                 return;
             }
         };
@@ -24,7 +24,7 @@ pub fn update() {
         return;
     }
 
-    println!("pkg: skaffold: updating ...");
+    println!("skaffold: updating ...");
 
     match utils::process::command_output("skaffold", &["version"]) {
         Ok(output) => {
@@ -47,12 +47,12 @@ fn install_release_asset(release: Release) {
     let asset = match latest_asset(&release) {
         Some(a) => a,
         None => {
-            println!("pkg: skaffold: no asset matches OS and ARCH");
+            println!("skaffold: no asset matches OS and ARCH");
             return;
         }
     };
 
-    println!("pkg: skaffold: installing ...");
+    println!("skaffold: installing ...");
 
     #[cfg(windows)]
     let bin_path = utils::env::home_dir().join(".local/bin/skaffold.exe");

--- a/src/tasks/ssh.rs
+++ b/src/tasks/ssh.rs
@@ -1,5 +1,4 @@
 use std::{fs, str};
-use std::path::Path;
 
 use regex;
 

--- a/src/tasks/ssh.rs
+++ b/src/tasks/ssh.rs
@@ -10,7 +10,7 @@ pub fn sync() {
         return;
     }
 
-    println!("pkg: ssh: syncing ...");
+    println!("ssh: syncing ...");
 
     let bits96_re = regex::Regex::new(r"\b96\b").unwrap();
     let cbc_re = regex::Regex::new(r"\bcbc\b").unwrap();
@@ -97,7 +97,7 @@ pub fn sync() {
     match fs::write(&target_path, String::from(&config)) {
         Ok(()) => {}
         Err(error) => {
-            println!("error: pkg: ssh: unable to write config: {}", error);
+            println!("error: ssh: unable to write config: {}", error);
         }
     }
 }

--- a/src/tasks/tmux.rs
+++ b/src/tasks/tmux.rs
@@ -7,7 +7,7 @@ pub fn sync() {
         return;
     }
 
-    println!("pkg: tmux: syncing ...");
+    println!("tmux: syncing ...");
 
     let src = utils::env::home_dir().join(".dotfiles/config/tmux.conf");
     let dest = utils::env::home_dir().join(".tmux.conf");
@@ -24,7 +24,7 @@ pub fn sync() {
         let tpm_url = "https://github.com/tmux-plugins/tpm.git";
         match utils::git::shallow_clone(&tpm_url, &tpm_path.to_str().unwrap()) {
             Ok(()) => {}
-            Err(error) => println!("pkg: tmux: unable to install tpm: {}", error),
+            Err(error) => println!("tmux: unable to install tpm: {}", error),
         }
     }
 
@@ -50,13 +50,13 @@ pub fn update() {
         return;
     }
 
-    println!("pkg: tmux: updating ...");
+    println!("tmux: updating ...");
 
     let tpm_path = utils::env::home_dir().join(".tmux/plugins/tpm");
     if utils::git::path_is_git_repository(&tpm_path) {
         match utils::git::shallow_fetch(&tpm_path.to_str().unwrap()) {
             Ok(()) => {}
-            Err(error) => println!("pkg: tmux: unable to update tpm: {}", error),
+            Err(error) => println!("tmux: unable to update tpm: {}", error),
         }
 
         let tpm_update_path = tpm_path.join("bin/update_plugins");

--- a/src/tasks/vim.rs
+++ b/src/tasks/vim.rs
@@ -2,14 +2,14 @@ use std;
 
 use utils;
 
-const ERROR_MSG: &str = "pkg: vim";
+const ERROR_MSG: &str = "vim";
 
 pub fn sync() {
     if !has_vim() {
         return;
     }
 
-    println!("pkg: vim: syncing...");
+    println!("vim: syncing...");
 
     // BEGIN: remove old vim configurations
     let vim_runtime = utils::env::home_dir().join(".vim_runtime");
@@ -40,7 +40,7 @@ pub fn update() {
         return;
     }
 
-    println!("pkg: vim: updating...");
+    println!("vim: updating...");
 
     fetch_vim_plug(false);
 

--- a/src/tasks/vscode.rs
+++ b/src/tasks/vscode.rs
@@ -20,7 +20,7 @@ pub fn sync() {
         return;
     }
 
-    println!("pkg: vscode: syncing ...");
+    println!("vscode: syncing ...");
 
     let src = utils::env::home_dir().join(".dotfiles/config/vscode.json");
 
@@ -39,7 +39,7 @@ pub fn sync() {
     let contents = match fs::read_to_string(&cfg_path) {
         Ok(s) => s,
         Err(error) => {
-            println!("pkg: vscode: ignoring config: {}", error);
+            println!("vscode: ignoring config: {}", error);
             return;
         }
     };

--- a/src/tasks/windows.rs
+++ b/src/tasks/windows.rs
@@ -1,7 +1,7 @@
 use utils;
 
 pub fn sync() {
-    println!("pkg: windows: manually configure %PATH% to include:");
+    println!("windows: manually configure %PATH% to include:");
 
     let bin_path = utils::env::home_dir().join(".local").join("bin");
     println!("- {}", bin_path.display());

--- a/src/tasks/yq.rs
+++ b/src/tasks/yq.rs
@@ -5,13 +5,13 @@ use utils::github::{Asset, Release};
 use utils::golang::{arch, os};
 
 pub fn sync() {
-    println!("pkg: yq: syncing ...");
+    println!("yq: syncing ...");
 
     if !is_installed() {
         let release = match utils::github::latest_release(&"mikefarah", &"yq") {
             Ok(r) => r,
             Err(error) => {
-                println!("error: pkg: yq: {}", error);
+                println!("error: yq: {}", error);
                 return;
             }
         };
@@ -24,7 +24,7 @@ pub fn update() {
         return;
     }
 
-    println!("pkg: yq: updating ...");
+    println!("yq: updating ...");
 
     match utils::process::command_output("yq", &["--version"]) {
         Ok(output) => {
@@ -43,12 +43,12 @@ fn install_release_asset(release: Release) {
     let asset = match latest_asset(&release) {
         Some(a) => a,
         None => {
-            println!("pkg: yq: no asset matches OS and ARCH");
+            println!("yq: no asset matches OS and ARCH");
             return;
         }
     };
 
-    println!("pkg: yq: installing ...");
+    println!("yq: installing ...");
 
     #[cfg(windows)]
     let bin_path = utils::env::home_dir().join(".local/bin/yq.exe");

--- a/src/utils/archive.rs
+++ b/src/utils/archive.rs
@@ -58,11 +58,13 @@ pub fn extract_tar(source: &Path, target: &Path) -> io::Result<()> {
             continue;
         }
 
-        println!("{}", &entry_path.display());
+        print!("."); // progress indicator
 
         entry.set_preserve_permissions(true);
         entry.unpack_in(&target)?;
     }
+
+    println!(""); // done
 
     Ok(())
 }
@@ -107,16 +109,16 @@ pub fn extract_zip(source: &Path, target: &Path) -> io::Result<()> {
             continue; // skip directories
         }
 
-        println!("{}", entry_path.display());
-
         let output_path = target.join(entry_path);
         std::fs::create_dir_all(&output_path.parent().unwrap_or(&output_path))?;
 
-        println!("{}", output_path.display());
+        print!("."); // progress indicator
 
         let mut output_file = File::create(&output_path).expect("unable to open destination file");
         std::io::copy(&mut entry, &mut output_file)?;
     }
+
+    println!(""); // done
 
     Ok(())
 }

--- a/src/utils/archive.rs
+++ b/src/utils/archive.rs
@@ -52,8 +52,6 @@ pub fn extract_tar(source: &Path, target: &Path) -> io::Result<()> {
         // Make sure there wasn't an I/O error
         let mut entry = entry?;
 
-        let entry_path = entry.header().path()?.into_owned();
-
         if !entry.header().entry_type().is_file() {
             continue;
         }

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -50,13 +50,6 @@ pub fn is_dir(target: &Path) -> bool {
     }
 }
 
-pub fn is_file(target: &Path) -> bool {
-    match std::fs::metadata(target) {
-        Ok(m) => m.is_file(),
-        Err(_error) => false,
-    }
-}
-
 #[cfg(unix)]
 pub fn set_executable(target: &Path) -> std::io::Result<()> {
     let file = File::open(target).unwrap();
@@ -161,13 +154,11 @@ mod tests {
     fn check_cargo() {
         let file_path = Path::new(env!("CARGO"));
         assert!(!is_dir(&file_path));
-        assert!(is_file(&file_path));
     }
 
     #[test]
     fn check_cargo_manifest_dir() {
         let project_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
         assert!(is_dir(&project_dir));
-        assert!(!is_file(&project_dir));
     }
 }

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -1,8 +1,6 @@
 use std::io;
 use std::path::Path;
 
-use mktemp;
-
 use utils;
 
 pub fn has_git() -> bool {
@@ -61,6 +59,8 @@ pub fn shallow_fetch<T: AsRef<str>>(target: &T) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use mktemp;
+
     use super::*;
 
     #[test]

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -3,7 +3,7 @@ use std::fs::{File, create_dir_all};
 use std::io::{self, ErrorKind, Write};
 use std::path::Path;
 
-use cabot::{self, Client, RequestBuilder, request::Request, response::Response};
+use cabot::{Client, RequestBuilder, request::Request, response::Response};
 
 struct HTTPCall<'a>(&'a Request, &'a Response);
 
@@ -117,6 +117,8 @@ fn user_agent() -> String {
 
 #[cfg(test)]
 mod tests {
+    use cabot;
+
     use super::*;
 
     #[test]

--- a/src/utils/ssh.rs
+++ b/src/utils/ssh.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
-use std::fs;
 use std::ops::BitOr;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use textwrap;
 use which;
@@ -961,6 +960,9 @@ fn parse_config_yesnoask(text: String) -> Option<YesNoAsk> {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::path::Path;
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
### Added

- golang: `sync` delete `dep` installed by `go get ...`

- golang: `sync`/`update` grab favourite packages listed in TOML (fixes #79)

- golang: `sync`/`update` grab linters with [gometalinter](https://github.com/alecthomas/gometalinter)

### Changed

- drop "pkg: " prefix from log output, etc

- less verbose archive extraction