### PR TITLE
nodejs: Windows: look for node.exe in the correct place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- nodejs: Windows: look for node.exe in the correct place
+
 - ssh: create ~/.ssh if missing
 
 ## [0.15.0] - 2018-06-06

--- a/src/tasks/nodejs.rs
+++ b/src/tasks/nodejs.rs
@@ -175,24 +175,14 @@ fn read_config() -> Config {
 }
 
 fn sync_npm_packages() {
-    #[cfg(windows)]
-    let nodejs_bin_dir: &Path = &utils::env::home_dir().join(".local/node");
-    #[cfg(not(windows))]
-    let nodejs_bin_dir: &Path = &utils::env::home_dir().join(".local/node/bin");
-
     // these often are included with the Windows version,
     // and prevent `npm` from updating itself
     for filename in &["npm", "npm.cmd", "npx", "npx.cmd"] {
-        utils::fs::delete_if_exists(&nodejs_bin_dir.join(Path::new(&filename)));
+        utils::fs::delete_if_exists(&utils::nodejs::bin_dir().join(Path::new(&filename)));
     }
 
-    #[cfg(windows)]
-    let nodejs_lib_dir: &Path = &utils::env::home_dir().join(".local/node");
-    #[cfg(not(windows))]
-    let nodejs_lib_dir: &Path = &utils::env::home_dir().join(".local/node/lib");
-
     if !utils::nodejs::has_npm() {
-        let npm_cli_path = nodejs_lib_dir.join("node_modules/npm/bin/npm-cli.js");
+        let npm_cli_path = utils::nodejs::lib_dir().join("node_modules/npm/bin/npm-cli.js");
         let npm_cli_path_string = npm_cli_path.as_os_str().to_string_lossy().into_owned();
         let npm_cli_path_str = npm_cli_path_string.as_str();
 

--- a/src/tasks/windows.rs
+++ b/src/tasks/windows.rs
@@ -9,9 +9,7 @@ pub fn sync() {
     let go_bin_path = utils::env::home_dir().join(".local").join("go").join("bin");
     println!("- {}", go_bin_path.display());
 
-    let node_bin_path = utils::env::home_dir().join(".local").join("node").join(
-        "bin",
-    );
+    let node_bin_path = utils::env::home_dir().join(".local").join("node");
     println!("- {}", node_bin_path.display());
 }
 

--- a/src/utils/archive.rs
+++ b/src/utils/archive.rs
@@ -1,6 +1,6 @@
 use std;
 use std::fs::File;
-use std::io::{self, BufReader, BufWriter, Read};
+use std::io::{self, BufReader, BufWriter};
 use std::path::Path;
 
 use libflate;
@@ -123,6 +123,8 @@ pub fn extract_zip(source: &Path, target: &Path) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Read;
+
     use super::*;
 
     #[test]

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,4 +1,5 @@
 use std;
+#[cfg(unix)]
 use std::fs::File;
 use std::io::Error;
 use std::path::Path;
@@ -59,7 +60,7 @@ pub fn set_executable(target: &Path) -> std::io::Result<()> {
 }
 
 #[cfg(not(unix))]
-pub fn set_executable(target: &Path) -> std::io::Result<()> {
+pub fn set_executable(_target: &Path) -> std::io::Result<()> {
     Ok(())
 }
 

--- a/src/utils/nodejs.rs
+++ b/src/utils/nodejs.rs
@@ -23,6 +23,13 @@ pub fn arch() -> &'static str {
     }
 }
 
+pub fn bin_dir() -> PathBuf {
+    #[cfg(windows)]
+    return install_path();
+    #[cfg(not(windows))]
+    return install_path().join("bin");
+}
+
 pub fn current_version() -> String {
     match utils::process::command_output("node", &["--version"]) {
         Ok(output) => {
@@ -38,9 +45,9 @@ pub fn current_version() -> String {
 
 pub fn has_node() -> bool {
     #[cfg(windows)]
-    let exe_path = install_path().join("bin").join("node.exe");
+    let exe_path = bin_dir().join("node.exe");
     #[cfg(not(windows))]
-    let exe_path = install_path().join("bin").join("node");
+    let exe_path = bin_dir().join("node");
 
     exe_path.is_file()
 }
@@ -78,7 +85,7 @@ pub fn has_yarn() -> bool {
     }
 }
 
-fn install_path() -> PathBuf {
+pub fn install_path() -> PathBuf {
     utils::env::home_dir().join(".local").join("node")
 }
 
@@ -104,6 +111,13 @@ pub fn latest_version() -> String {
         .unwrap();
 
     String::from(latest_release.version.as_str().trim())
+}
+
+pub fn lib_dir() -> PathBuf {
+    #[cfg(windows)]
+    return install_path();
+    #[cfg(not(windows))]
+    return install_path().join("lib");
 }
 
 pub fn os() -> &'static str {


### PR DESCRIPTION
### Fixed

- nodejs: Windows: look for node.exe in the correct place

- fixes #82 