### PR TITLE
macOS: wipe Quick Look cache during `sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- macOS: wipe Quick Look cache during `sync`
+
 ## [0.15.1] - 2018-06-10
 
 ### Fixed

--- a/src/tasks/macos.rs
+++ b/src/tasks/macos.rs
@@ -1,0 +1,12 @@
+use utils;
+
+pub fn sync() {
+    println!("macos: syncing ...");
+
+    match utils::process::command_spawn_wait("qlmanage", &["-d", "1", "-r", "cache"]) {
+        Ok(_) => {}
+        Err(error) => println!("macos: unable to wipe Quick Look cache: {}", error),
+    }
+}
+
+pub fn update() {}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -6,6 +6,8 @@ mod git;
 mod golang;
 mod hyper;
 mod jq;
+#[cfg(target_os = "macos")]
+mod macos;
 mod nodejs;
 mod psql;
 mod rust;
@@ -30,6 +32,8 @@ pub fn sync() {
     golang::sync();
     hyper::sync();
     jq::sync();
+    #[cfg(target_os = "macos")]
+    macos::sync();
     nodejs::sync();
     psql::sync();
     rust::sync();
@@ -55,6 +59,8 @@ pub fn update() {
     golang::update();
     hyper::update();
     jq::update();
+    #[cfg(target_os = "macos")]
+    macos::update();
     nodejs::update();
     psql::update();
     rust::update();

--- a/src/tasks/vscode.rs
+++ b/src/tasks/vscode.rs
@@ -26,7 +26,7 @@ pub fn sync() {
 
     #[cfg(target_os = "macos")]
     let settings_path = "Library/Application Support/Code/User/settings.json";
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     let settings_path = "AppData/Roaming/Code/User/settings.json";
     #[cfg(not(any(target_os = "macos",windows)))]
     let settings_path = ".config/Code/User/settings.json";


### PR DESCRIPTION
### Added

- macOS: wipe Quick Look cache during `sync`

- fixes #86 