### PR TITLE
refactor GitHub release tasks

### DIFF
--- a/src/lib/ghrtask.rs
+++ b/src/lib/ghrtask.rs
@@ -1,0 +1,108 @@
+use std::{self, io};
+
+use utils;
+use utils::github::{self, Asset, Release};
+
+// GHRTask simplifies tasks that install from GitHub Releases.
+pub struct GHRTask<'a> {
+    pub asset_filter: fn(&Asset) -> bool,
+    pub command: &'a str,
+    pub repo: (&'a str, &'a str),
+    pub trim_version: fn(String) -> String,
+    pub version_arg: &'a str,
+}
+
+impl<'a> GHRTask<'a> {
+    pub fn update(&self) -> io::Result<()> {
+        if !self.exists() {
+            return Ok(());
+        }
+        println!("{}: updating...", &self.command);
+
+        let current = self.current_version();
+        match github::release_versus_current(
+            &current,
+            &String::from(self.repo.0),
+            &String::from(self.repo.1),
+        ) {
+            Some(r) => self.install_release(&r)?,
+            None => {}
+        };
+        Ok(())
+    }
+
+    pub fn sync(&self) -> io::Result<()> {
+        if self.exists() {
+            return Ok(());
+        }
+        println!("{}: syncing...", &self.command);
+
+        let release = match self.latest_release() {
+            Ok(r) => r,
+            Err(error) => {
+                println!(
+                    "error: unable to check latest release: {:?} {:?}",
+                    &self.repo, error
+                );
+                return Ok(());
+            }
+        };
+        self.install_release(&release)?;
+        Ok(())
+    }
+
+    fn current_version(&self) -> String {
+        let stdout = match utils::process::command_output(&self.command, &[&self.version_arg]) {
+            Ok(o) => String::from_utf8(o.stdout).unwrap_or_default(),
+            Err(error) => {
+                println!(
+                    "error: `{} {}`: {}",
+                    &self.command, &self.version_arg, error
+                );
+                String::new()
+            }
+        };
+        let trimmed = (self.trim_version)(String::from(stdout));
+        if trimmed.len() == 0 {
+            String::from("unexpected")
+        } else {
+            String::from(trimmed)
+        }
+    }
+
+    fn exists(&self) -> bool {
+        match utils::process::command_output(&self.command, &[&self.version_arg]) {
+            Ok(output) => output.status.success(),
+            Err(_error) => false,
+        }
+    }
+
+    fn install_release(&self, release: &Release) -> io::Result<()> {
+        let asset = match release
+            .assets
+            .to_vec()
+            .into_iter()
+            .filter(self.asset_filter)
+            .next()
+        {
+            Some(a) => a,
+            None => {
+                println!("warning: {}: no asset matches OS and ARCH", &self.command);
+                return Ok(());
+            }
+        };
+        println!("{}: installing...", &self.command);
+
+        let bin_path = utils::env::home_dir()
+            .join(".local")
+            .join("bin")
+            .join(&self.command);
+        github::download_release_asset(asset, &bin_path);
+
+        Ok(())
+    }
+
+    fn latest_release(&self) -> Result<Release, github::GitHubError> {
+        github::latest_release(&self.repo.0, &self.repo.1)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,9 @@ extern crate zip;
 
 use clap::{App, SubCommand};
 
+mod lib {
+    pub mod ghrtask;
+}
 mod tasks;
 mod utils {
     pub mod archive;

--- a/src/tasks/dep.rs
+++ b/src/tasks/dep.rs
@@ -4,19 +4,6 @@ use lib::ghrtask::GHRTask;
 use utils::github::Asset;
 use utils::golang::{arch, os};
 
-const ERROR_MSG: &str = "error: dep";
-
-const GHR_TASK: GHRTask = GHRTask {
-    asset_filter: asset_filter,
-    #[cfg(windows)]
-    command: "dep.exe",
-    #[cfg(not(windows))]
-    command: "dep",
-    repo: ("golang", "dep"),
-    trim_version: trim_version,
-    version_arg: "version",
-};
-
 pub fn sync() {
     match GHR_TASK.sync() {
         Ok(_) => {}
@@ -30,6 +17,17 @@ pub fn update() {
         Err(_) => {}
     }
 }
+
+const GHR_TASK: GHRTask = GHRTask {
+    asset_filter: asset_filter,
+    #[cfg(windows)]
+    command: "dep.exe",
+    #[cfg(not(windows))]
+    command: "dep",
+    repo: ("golang", "dep"),
+    trim_version: trim_version,
+    version_arg: "version",
+};
 
 fn asset_filter(asset: &Asset) -> bool {
     #[cfg(windows)]

--- a/src/tasks/dep.rs
+++ b/src/tasks/dep.rs
@@ -1,66 +1,46 @@
 use std;
 
-use utils;
-use utils::github::{Asset, Release};
+use lib::ghrtask::GHRTask;
+use utils::github::Asset;
 use utils::golang::{arch, os};
 
 const ERROR_MSG: &str = "error: dep";
 
-pub fn sync() {
-    println!("dep: syncing ...");
+const GHR_TASK: GHRTask = GHRTask {
+    asset_filter: asset_filter,
+    #[cfg(windows)]
+    command: "dep.exe",
+    #[cfg(not(windows))]
+    command: "dep",
+    repo: ("golang", "dep"),
+    trim_version: trim_version,
+    version_arg: "version",
+};
 
-    if !is_installed() {
-        let release = match utils::github::latest_release(&"golang", &"dep") {
-            Ok(r) => r,
-            Err(error) => {
-                println!("error: dep: {}", error);
-                return;
-            }
-        };
-        install_release_asset(release);
+pub fn sync() {
+    match GHR_TASK.sync() {
+        Ok(_) => {}
+        Err(_) => {}
     }
 }
 
 pub fn update() {
-    if !is_installed() {
-        return;
+    match GHR_TASK.update() {
+        Ok(_) => {}
+        Err(_) => {}
     }
-
-    println!("dep: updating ...");
-
-    let current = installed_version();
-    match utils::github::release_versus_current(
-        &current,
-        &String::from("golang"),
-        &String::from("dep"),
-    ) {
-        Some(r) => install_release_asset(r),
-        None => {}
-    };
 }
 
-fn install_release_asset(release: Release) {
-    let asset = match latest_asset(&release) {
-        Some(a) => a,
-        None => {
-            println!("dep: no asset matches OS and ARCH");
-            return;
-        }
-    };
-
-    println!("dep: installing ...");
-
+fn asset_filter(asset: &Asset) -> bool {
     #[cfg(windows)]
-    let bin_path = utils::env::home_dir().join(".local/bin/dep.exe");
+    let name = format!("dep-{}-{}.exe", os(), arch());
     #[cfg(not(windows))]
-    let bin_path = utils::env::home_dir().join(".local/bin/dep");
+    let name = format!("dep-{}-{}", os(), arch());
 
-    utils::github::download_release_asset(asset, &bin_path);
+    asset.name == name
 }
 
-fn installed_version() -> String {
-    let output = utils::process::command_output("dep", &["version"]).expect(ERROR_MSG);
-    let stdout = std::str::from_utf8(&output.stdout).unwrap_or_default();
+fn trim_version(stdout: String) -> String {
     for line in stdout.lines() {
         let parts: Vec<&str> = line.splitn(2, ":").collect();
         if parts[0].trim() == "version" {
@@ -68,27 +48,4 @@ fn installed_version() -> String {
         }
     }
     String::from("unexpected")
-}
-
-fn is_installed() -> bool {
-    match utils::process::command_output("dep", &["version"]) {
-        Ok(output) => output.status.success(),
-        Err(_error) => false,
-    }
-}
-
-fn latest_asset(release: &Release) -> Option<Asset> {
-    return release
-        .assets
-        .to_vec()
-        .into_iter()
-        .filter(|asset| {
-            #[cfg(windows)]
-            let name = format!("dep-{}-{}.exe", os(), arch());
-            #[cfg(not(windows))]
-            let name = format!("dep-{}-{}", os(), arch());
-
-            asset.name == name
-        })
-        .next();
 }

--- a/src/tasks/skaffold.rs
+++ b/src/tasks/skaffold.rs
@@ -1,86 +1,44 @@
 use std;
+use std::env::consts::{ARCH, OS};
 
-use utils;
-use utils::github::{Asset, Release};
+use lib::ghrtask::GHRTask;
+use utils::github::Asset;
 use utils::golang::{arch, os};
 
 pub fn sync() {
-    println!("skaffold: syncing ...");
-
-    if !is_installed() {
-        let release = match utils::github::latest_release(&"GoogleCloudPlatform", &"skaffold") {
-            Ok(r) => r,
-            Err(error) => {
-                println!("error: skaffold: {}", error);
-                return;
-            }
-        };
-        install_release_asset(release);
+    match GHR_TASK.sync() {
+        Ok(_) => {}
+        Err(_) => {}
     }
 }
 
 pub fn update() {
-    if !is_installed() {
-        return;
+    match GHR_TASK.update() {
+        Ok(_) => {}
+        Err(_) => {}
     }
-
-    println!("skaffold: updating ...");
-
-    match utils::process::command_output("skaffold", &["version"]) {
-        Ok(output) => {
-            let stdout = std::str::from_utf8(&output.stdout).unwrap_or_default();
-
-            match utils::github::release_versus_current(
-                &stdout,
-                &"GoogleCloudPlatform",
-                &"skaffold",
-            ) {
-                Some(r) => install_release_asset(r),
-                None => {}
-            }
-        }
-        Err(_error) => {}
-    };
 }
 
-fn install_release_asset(release: Release) {
-    let asset = match latest_asset(&release) {
-        Some(a) => a,
-        None => {
-            println!("skaffold: no asset matches OS and ARCH");
-            return;
-        }
-    };
-
-    println!("skaffold: installing ...");
-
+const GHR_TASK: GHRTask = GHRTask {
+    asset_filter: asset_filter,
     #[cfg(windows)]
-    let bin_path = utils::env::home_dir().join(".local/bin/skaffold.exe");
+    command: "skaffold.exe",
     #[cfg(not(windows))]
-    let bin_path = utils::env::home_dir().join(".local/bin/skaffold");
+    command: "skaffold",
+    repo: ("GoogleCloudPlatform", "skaffold"),
+    trim_version: trim_version,
+    version_arg: "version",
+};
 
-    utils::github::download_release_asset(asset, &bin_path);
+fn asset_filter(asset: &Asset) -> bool {
+    #[cfg(windows)]
+    let name = format!("skaffold-{}-{}.exe", os(), arch());
+    #[cfg(not(windows))]
+    let name = format!("skaffold-{}-{}", os(), arch());
+
+    asset.name == name
 }
 
-fn is_installed() -> bool {
-    match utils::process::command_output("skaffold", &["version"]) {
-        Ok(output) => output.status.success(),
-        Err(_error) => false,
-    }
-}
-
-fn latest_asset(release: &Release) -> Option<Asset> {
-    return release
-        .assets
-        .to_vec()
-        .into_iter()
-        .filter(|asset| {
-            #[cfg(windows)]
-            let name = format!("skaffold-{}-{}.exe", os(), arch());
-            #[cfg(not(windows))]
-            let name = format!("skaffold-{}-{}", os(), arch());
-
-            asset.name == name
-        })
-        .next();
+fn trim_version(stdout: String) -> String {
+    String::from(stdout.trim())
 }

--- a/src/tasks/vim.rs
+++ b/src/tasks/vim.rs
@@ -91,8 +91,6 @@ pub fn update() {
     }
 }
 
-fn fetch_vim_plug(skip_if_exists: bool) {}
-
 #[derive(Debug)]
 struct Vim<'a> {
     autoload_parent_dir: &'a str, // used in: $HOME/autoload_dir/autoload


### PR DESCRIPTION
- identified dep, jq, skaffold, and yq tasks as duplicating logic for installation via GitHub Release
- extracted this, so these tasks are now more declarative