### PR TITLE
functions accept `Into<A> + AsRef<B>` types

### DIFF
--- a/src/lib/ghrtask.rs
+++ b/src/lib/ghrtask.rs
@@ -21,9 +21,9 @@ impl<'a> GHRTask<'a> {
 
         let current = self.current_version();
         match github::release_versus_current(
-            &current,
-            &String::from(self.repo.0),
-            &String::from(self.repo.1),
+            current,
+            String::from(self.repo.0),
+            String::from(self.repo.1),
         ) {
             Some(r) => self.install_release(&r)?,
             None => {}
@@ -52,7 +52,7 @@ impl<'a> GHRTask<'a> {
     }
 
     fn current_version(&self) -> String {
-        let stdout = match utils::process::command_output(&self.command, &[&self.version_arg]) {
+        let stdout = match utils::process::command_output(&self.command, &[self.version_arg]) {
             Ok(o) => String::from_utf8(o.stdout).unwrap_or_default(),
             Err(error) => {
                 println!(
@@ -71,7 +71,7 @@ impl<'a> GHRTask<'a> {
     }
 
     fn exists(&self) -> bool {
-        match utils::process::command_output(&self.command, &[&self.version_arg]) {
+        match utils::process::command_output(&self.command, &[self.version_arg]) {
             Ok(output) => output.status.success(),
             Err(_error) => false,
         }
@@ -103,6 +103,6 @@ impl<'a> GHRTask<'a> {
     }
 
     fn latest_release(&self) -> Result<Release, github::GitHubError> {
-        github::latest_release(&self.repo.0, &self.repo.1)
+        github::latest_release(String::from(self.repo.0), String::from(self.repo.1))
     }
 }

--- a/src/tasks/golang.rs
+++ b/src/tasks/golang.rs
@@ -54,7 +54,7 @@ pub fn sync() {
             }
         };
 
-        match install_golang(&latest_version) {
+        match install_golang(latest_version) {
             Ok(_) => {}
             Err(error) => {
                 println!("error: golang: unable to install: {:?}", error);
@@ -104,7 +104,7 @@ pub fn update() {
 
     println!("current={} latest={}", &current_version, &latest_version);
     if current_version != latest_version {
-        match install_golang(&latest_version) {
+        match install_golang(latest_version) {
             Ok(_) => {}
             Err(error) => {
                 println!("error: golang: unable to install: {:?}", error);
@@ -134,8 +134,11 @@ pub fn update() {
     };
 }
 
-fn install_golang(version: &str) -> Result<(), utils::golang::GolangError> {
-    println!("golang: installing {} ...", &version);
+fn install_golang<S>(version: S) -> Result<(), utils::golang::GolangError>
+where
+    S: Into<String> + AsRef<str>,
+{
+    println!("golang: installing {} ...", version.as_ref());
 
     let temp_path;
     {
@@ -147,14 +150,14 @@ fn install_golang(version: &str) -> Result<(), utils::golang::GolangError> {
     #[cfg(windows)]
     let remote_url = format!(
         "https://dl.google.com/go/{}.{}-{}.zip",
-        version,
+        version.as_ref(),
         os(),
         arch()
     );
     #[cfg(not(windows))]
     let remote_url = format!(
         "https://dl.google.com/go/{}.{}-{}.tar.gz",
-        version,
+        version.as_ref(),
         os(),
         arch()
     );

--- a/src/tasks/golang.rs
+++ b/src/tasks/golang.rs
@@ -159,7 +159,7 @@ fn install_golang(version: &str) -> Result<(), utils::golang::GolangError> {
         arch()
     );
 
-    utils::http::download(&remote_url, &temp_path)?;
+    utils::http::download(remote_url, &temp_path)?;
 
     let local_path = utils::env::home_dir().join(".local");
     let target_path = local_path.join("go");

--- a/src/tasks/nodejs.rs
+++ b/src/tasks/nodejs.rs
@@ -101,7 +101,7 @@ fn install_nodejs(version: &str) -> io::Result<()> {
     #[cfg(not(windows))]
     let remote_url = format!("https://nodejs.org/dist/{}/{}.tar.gz", version, &prefix);
 
-    match utils::http::download(&remote_url, &temp_path) {
+    match utils::http::download(remote_url, &temp_path) {
         Ok(()) => {}
         Err(error) => {
             println!("error: cannot download: {}", error);

--- a/src/tasks/shfmt.rs
+++ b/src/tasks/shfmt.rs
@@ -8,7 +8,7 @@ pub fn sync() {
     println!("shfmt: syncing ...");
 
     if !is_installed() {
-        let release = match utils::github::latest_release(&"mvdan", &"sh") {
+        let release = match utils::github::latest_release("mvdan", "sh") {
             Ok(r) => r,
             Err(error) => {
                 println!("error: shfmt: {}", error);
@@ -30,7 +30,7 @@ pub fn update() {
         Ok(output) => {
             let stdout = std::str::from_utf8(&output.stdout).unwrap_or_default();
 
-            match utils::github::release_versus_current(&stdout, &"mvdan", &"sh") {
+            match utils::github::release_versus_current(stdout, "mvdan", "sh") {
                 Some(r) => install_release_asset(r),
                 None => {}
             }

--- a/src/tasks/ssh.rs
+++ b/src/tasks/ssh.rs
@@ -27,45 +27,54 @@ pub fn sync() {
     };
 
     let version = ssh_version();
-    let do_blacklist = is_blacklist_supported(&version);
+    let do_blacklist = is_blacklist_supported(version);
 
     let mut config = Config::from(target.as_str()) | Config::from(source.as_str());
 
-    let ciphers: Vec<String> = supported_ssh_ciphers().iter().filter_map(|cipher| {
-        if !do_blacklist && !is_weak_cipher(cipher) {
-            return Some(cipher.clone());
-        }
-        if do_blacklist && is_weak_cipher(cipher) {
-            return Some(format!("-{}", cipher));
-        }
-        None
-    }).collect();
+    let ciphers: Vec<String> = supported_ssh_ciphers()
+        .iter()
+        .filter_map(|cipher| {
+            if !do_blacklist && !is_weak_cipher(cipher as &str) {
+                return Some(cipher.clone());
+            }
+            if do_blacklist && is_weak_cipher(cipher as &str) {
+                return Some(format!("-{}", cipher));
+            }
+            None
+        })
+        .collect();
     if ciphers.len() > 0 {
         config.Ciphers = Some(ciphers);
     }
 
-    let kexs: Vec<String> = supported_ssh_kexs().iter().filter_map(|kex| {
-        if !do_blacklist && !is_weak_kex(kex) {
-            return Some(kex.clone());
-        }
-        if do_blacklist && is_weak_kex(kex) {
-            return Some(format!("-{}", kex));
-        }
-        None
-    }).collect();
+    let kexs: Vec<String> = supported_ssh_kexs()
+        .iter()
+        .filter_map(|kex| {
+            if !do_blacklist && !is_weak_kex(kex as &str) {
+                return Some(kex.clone());
+            }
+            if do_blacklist && is_weak_kex(kex as &str) {
+                return Some(format!("-{}", kex));
+            }
+            None
+        })
+        .collect();
     if kexs.len() > 0 {
         config.KexAlgorithms = Some(kexs);
     }
 
-    let macs: Vec<String> = supported_ssh_macs().iter().filter_map(|mac| {
-        if !do_blacklist && !is_weak_mac(mac) {
-            return Some(mac.clone());
-        }
-        if do_blacklist && is_weak_mac(mac) {
-            return Some(format!("-{}", mac));
-        }
-        None
-    }).collect();
+    let macs: Vec<String> = supported_ssh_macs()
+        .iter()
+        .filter_map(|mac| {
+            if !do_blacklist && !is_weak_mac(mac as &str) {
+                return Some(mac.clone());
+            }
+            if do_blacklist && is_weak_mac(mac as &str) {
+                return Some(format!("-{}", mac));
+            }
+            None
+        })
+        .collect();
     if macs.len() > 0 {
         config.MACs = Some(macs);
     }
@@ -85,9 +94,12 @@ pub fn sync() {
 
 pub fn update() {}
 
-fn is_blacklist_supported(ssh_version: &str) -> bool {
+fn is_blacklist_supported<S>(ssh_version: S) -> bool
+where
+    S: Into<String> + AsRef<str>,
+{
     let re = regex::Regex::new(r"OpenSSH_(\d+\.\d+)").unwrap();
-    for caps in re.captures_iter(ssh_version) {
+    for caps in re.captures_iter(ssh_version.as_ref()) {
         let version = caps.get(1).unwrap().as_str();
         match version.parse::<f32>() {
             Ok(v) => {
@@ -100,24 +112,33 @@ fn is_blacklist_supported(ssh_version: &str) -> bool {
     true
 }
 
-fn is_weak_cipher(cipher: &str) -> bool {
+fn is_weak_cipher<S>(cipher: S) -> bool
+where
+    S: Into<String> + AsRef<str>,
+{
     let cbc_re = regex::Regex::new(r"\bcbc\b").unwrap();
     let rc4_re = regex::Regex::new(r"\b(arcfour|rc4)").unwrap();
     // no ending word-boundary: need to catch "arcfour" and "arcfour128"
 
     // CBC ciphers are weak: https://access.redhat.com/solutions/420283
     // RC4 ciphers are weak: https://en.wikipedia.org/wiki/RC4#Security
-    cbc_re.is_match(cipher) || rc4_re.is_match(cipher)
+    cbc_re.is_match(cipher.as_ref()) || rc4_re.is_match(cipher.as_ref())
 }
 
-fn is_weak_kex(kex: &str) -> bool {
+fn is_weak_kex<S>(kex: S) -> bool
+where
+    S: Into<String> + AsRef<str>,
+{
     let sha1_re = regex::Regex::new(r"\bsha1\b").unwrap();
 
     // SHA1 is weak: https://en.wikipedia.org/wiki/SHA-1
-    sha1_re.is_match(kex)
+    sha1_re.is_match(kex.as_ref())
 }
 
-fn is_weak_mac(mac: &str) -> bool {
+fn is_weak_mac<S>(mac: S) -> bool
+where
+    S: Into<String> + AsRef<str>,
+{
     let bits96_re = regex::Regex::new(r"\b96\b").unwrap();
     let md5_re = regex::Regex::new(r"\bmd5\b").unwrap();
     let sha1_re = regex::Regex::new(r"\bsha1\b").unwrap();
@@ -125,7 +146,9 @@ fn is_weak_mac(mac: &str) -> bool {
     // 96-bit algorithms are weak: https://access.redhat.com/solutions/420283
     // MD5 is weak: https://access.redhat.com/solutions/420283
     // SHA1 is weak: https://en.wikipedia.org/wiki/SHA-1
-    bits96_re.is_match(mac) || md5_re.is_match(mac) || sha1_re.is_match(mac)
+    bits96_re.is_match(mac.as_ref())
+        || md5_re.is_match(mac.as_ref())
+        || sha1_re.is_match(mac.as_ref())
 }
 
 fn ssh_version() -> String {
@@ -139,10 +162,7 @@ fn supported_ssh_ciphers() -> Vec<String> {
     match utils::process::command_output("ssh", &["-Q", "cipher"]) {
         Ok(output) => {
             let stdout = str::from_utf8(&output.stdout).unwrap_or_default();
-            stdout
-                .lines()
-                .map(|l| String::from(l.trim()))
-                .collect()
+            stdout.lines().map(|l| String::from(l.trim())).collect()
         }
         Err(_error) => Vec::<String>::new(),
     }
@@ -152,10 +172,7 @@ fn supported_ssh_kexs() -> Vec<String> {
     match utils::process::command_output("ssh", &["-Q", "kex"]) {
         Ok(output) => {
             let stdout = str::from_utf8(&output.stdout).unwrap_or_default();
-            stdout
-                .lines()
-                .map(|l| String::from(l.trim()))
-                .collect()
+            stdout.lines().map(|l| String::from(l.trim())).collect()
         }
         Err(_error) => Vec::<String>::new(),
     }
@@ -165,10 +182,7 @@ fn supported_ssh_macs() -> Vec<String> {
     match utils::process::command_output("ssh", &["-Q", "mac"]) {
         Ok(output) => {
             let stdout = str::from_utf8(&output.stdout).unwrap_or_default();
-            stdout
-                .lines()
-                .map(|l| String::from(l.trim()))
-                .collect()
+            stdout.lines().map(|l| String::from(l.trim())).collect()
         }
         Err(_error) => Vec::<String>::new(),
     }
@@ -183,8 +197,8 @@ mod tests {
     #[test]
     fn is_blacklist_supported_by_versions() {
         let old_version = "OpenSSH_7.4p1 Debian-10+deb9u3, OpenSSL 1.0.2l  25 May 2017";
-        assert_eq!(is_blacklist_supported(&old_version), false);
-        assert_eq!(is_blacklist_supported(&""), true);
+        assert_eq!(is_blacklist_supported(old_version), false);
+        assert_eq!(is_blacklist_supported(""), true);
     }
 
     #[test]

--- a/src/tasks/tmux.rs
+++ b/src/tasks/tmux.rs
@@ -22,7 +22,7 @@ pub fn sync() {
 
     if !utils::git::path_is_git_repository(&tpm_path) {
         let tpm_url = "https://github.com/tmux-plugins/tpm.git";
-        match utils::git::shallow_clone(&tpm_url, &tpm_path.to_str().unwrap()) {
+        match utils::git::shallow_clone(tpm_url, &tpm_path.to_string_lossy()) {
             Ok(()) => {}
             Err(error) => println!("tmux: unable to install tpm: {}", error),
         }
@@ -54,7 +54,7 @@ pub fn update() {
 
     let tpm_path = utils::env::home_dir().join(".tmux/plugins/tpm");
     if utils::git::path_is_git_repository(&tpm_path) {
-        match utils::git::shallow_fetch(&tpm_path.to_str().unwrap()) {
+        match utils::git::shallow_fetch(tpm_path.to_string_lossy()) {
             Ok(()) => {}
             Err(error) => println!("tmux: unable to update tpm: {}", error),
         }

--- a/src/tasks/vim.rs
+++ b/src/tasks/vim.rs
@@ -126,7 +126,7 @@ impl<'a> Vim<'a> {
         let vim_plug = self.autoload_dir().join(PLUG_VIM);
         let vim_plug_url =
             String::from("https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim");
-        utils::http::download(&vim_plug_url, &vim_plug)?;
+        utils::http::download(vim_plug_url, vim_plug)?;
         Ok(())
     }
 

--- a/src/utils/golang.rs
+++ b/src/utils/golang.rs
@@ -82,7 +82,7 @@ pub fn is_installed() -> bool {
 }
 
 pub fn latest_version() -> Result<String, GolangError> {
-    let tags: Vec<utils::github::Tag> = match utils::github::fetch_tags(&"golang", &"go") {
+    let tags: Vec<utils::github::Tag> = match utils::github::fetch_tags("golang", "go") {
         Ok(t) => {
             t.into_iter()
                 .filter(|t| {

--- a/src/utils/nodejs.rs
+++ b/src/utils/nodejs.rs
@@ -88,7 +88,7 @@ pub fn install_path() -> PathBuf {
 }
 
 pub fn latest_version() -> String {
-    let req = utils::http::create_request(&DIST_JSON_URL, &utils::http::EMPTY_HEADERS);
+    let req = utils::http::create_request(DIST_JSON_URL, &utils::http::EMPTY_HEADERS);
     let res = utils::http::fetch_request(&req).expect(ERROR_MSG);
     let body = res.body_as_string().expect(ERROR_MSG);
     let releases: Vec<Release> = serde_json::from_str(&body).expect(ERROR_MSG);

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -1,17 +1,26 @@
-use std::io::Error;
 use std::process::Command;
 use std::process::ExitStatus;
 use std::process::Output;
-use std::str;
+use std::{
+    ffi::{OsStr, OsString}, io, str,
+};
 
 #[cfg(not(windows))]
-pub fn command_output<'a, T: AsRef<str>>(cmd: &str, args: &[T]) -> Result<Output, Error> {
+pub fn command_output<O, S>(cmd: O, args: &[S]) -> io::Result<Output>
+where
+    O: Into<OsString> + AsRef<OsStr>,
+    S: Into<String> + AsRef<str>,
+{
     let cmd_args: Vec<&str> = args.into_iter().map(|s| s.as_ref()).collect();
     return Command::new(cmd).args(cmd_args).output();
 }
 
 #[cfg(windows)]
-pub fn command_output<'a, T: AsRef<str>>(cmd: &str, args: &[T]) -> Result<Output, Error> {
+pub fn command_output<O, S>(cmd: O, args: &[S]) -> io::Result<Output>
+where
+    O: Into<OsString> + AsRef<OsStr>,
+    S: Into<String> + AsRef<str>,
+{
     let mut cmd_args = Vec::<&str>::new();
     cmd_args.push("/c");
     cmd_args.push(cmd);
@@ -20,13 +29,21 @@ pub fn command_output<'a, T: AsRef<str>>(cmd: &str, args: &[T]) -> Result<Output
 }
 
 #[cfg(not(windows))]
-pub fn command_spawn_wait<'a, T: AsRef<str>>(cmd: &str, args: &[T]) -> Result<ExitStatus, Error> {
+pub fn command_spawn_wait<O, S>(cmd: O, args: &[S]) -> io::Result<ExitStatus>
+where
+    O: Into<OsString> + AsRef<OsStr>,
+    S: Into<String> + AsRef<str>,
+{
     let cmd_args: Vec<&str> = args.into_iter().map(|s| s.as_ref()).collect();
     return Command::new(cmd).args(cmd_args).spawn()?.wait();
 }
 
 #[cfg(windows)]
-pub fn command_spawn_wait<'a, T: AsRef<str>>(cmd: &str, args: &[T]) -> Result<ExitStatus, Error> {
+pub fn command_spawn_wait<O, S>(cmd: O, args: &[S]) -> io::Result<ExitStatus>
+where
+    O: Into<OsString> + AsRef<OsStr>,
+    S: Into<String> + AsRef<str>,
+{
     let mut cmd_args = Vec::<&str>::new();
     cmd_args.push("/c");
     cmd_args.push(cmd);


### PR DESCRIPTION
- functions accept `Into<A> + AsRef<B>` types

  - e.g. `Into<String> + AsRef<str>` instead of strictly `String` or `&str`

  - similarly for `PathBuf` and `Path`

  - similarly for `OsString` and `OsStr`

- fixes #101 