### PR TITLE
git-sizer: keep git-sizer `sync`ed and `update`d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- git-sizer: keep [vale](https://github.com/github/git-sizer) `sync`ed and `update`d
+
 - vale: keep [vale](https://github.com/errata-ai/vale) `sync`ed and `update`d
 
 ## [0.17.0] - 2018-07-20

--- a/src/lib/ghratask.rs
+++ b/src/lib/ghratask.rs
@@ -2,7 +2,7 @@ use std::{fs, io};
 
 use lib::ghrtask::GHRTask;
 use utils::{
-    self, archive::{extract_tar_gz, extract_zip}, fs::{mkdtemp, mktemp},
+    self, archive::{extract_tar_gz, extract_zip}, fs::{mkdtemp, mktemp, set_executable},
     github::{self, Asset, Release},
 };
 
@@ -116,6 +116,7 @@ impl<'a> GHRATask<'a> {
             &bin_path.display(),
         );
         fs::copy(&extract_path.join(&self.command), &bin_path)?;
+        set_executable(&bin_path)?;
 
         fs::remove_dir_all(&extract_path)?;
 

--- a/src/tasks/gitsizer.rs
+++ b/src/tasks/gitsizer.rs
@@ -1,0 +1,41 @@
+use regex::Regex;
+
+use lib::ghratask::GHRATask;
+use utils::{
+    github::Asset, golang::{arch, os},
+};
+
+pub fn sync() {
+    match GHRA_TASK.sync() {
+        Ok(_) => {}
+        Err(_) => {}
+    }
+}
+
+pub fn update() {
+    match GHRA_TASK.update() {
+        Ok(_) => {}
+        Err(_) => {}
+    }
+}
+
+const GHRA_TASK: GHRATask = GHRATask {
+    asset_filter: asset_filter,
+    #[cfg(windows)]
+    command: "git-sizer.exe",
+    #[cfg(not(windows))]
+    command: "git-sizer",
+    repo: ("github", "git-sizer"),
+    trim_version: trim_version,
+    version_arg: "--version",
+};
+
+fn asset_filter(asset: &Asset) -> bool {
+    let re = Regex::new(&format!(r"^git-sizer-.*-{}-{}\.zip$", os(), arch())).unwrap();
+
+    re.is_match(&asset.name)
+}
+
+fn trim_version(stdout: String) -> String {
+    String::from(stdout.trim())
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -4,6 +4,7 @@ mod dep;
 mod dotfiles;
 mod git;
 mod gitleaks;
+mod gitsizer;
 mod golang;
 mod hadolint;
 mod hyper;
@@ -34,6 +35,7 @@ pub fn sync() {
     dep::sync();
     git::sync();
     gitleaks::sync();
+    gitsizer::sync();
     golang::sync();
     hadolint::sync();
     hyper::sync();
@@ -65,6 +67,7 @@ pub fn update() {
     dep::update();
     git::update();
     gitleaks::update();
+    gitsizer::update();
     golang::update();
     hadolint::update();
     hyper::update();


### PR DESCRIPTION
### Added

- git-sizer: keep [vale](https://github.com/github/git-sizer) `sync`ed and `update`d

- fixes #26 