### PR TITLE
bash: keep bash-it `sync`ed and `update`d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- bash: keep [bash-it](https://github.com/Bash-it/bash-it) `sync`ed and `update`d
+
 - zsh: keep [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) `sync`ed and `update`d
 
 - zsh: keep [pure](https://github.com/sindresorhus/pure) theme `sync`ed and `update`d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - zsh: keep [pure](https://github.com/sindresorhus/pure) theme `sync`ed and `update`d
 
+### Fixed
+
+- minikube: parse `minikube version` output better
+
 ## [0.18.0] -2018-07-28
 
 ### Added

--- a/src/tasks/bash.rs
+++ b/src/tasks/bash.rs
@@ -1,0 +1,86 @@
+use utils;
+
+pub fn sync() {
+    if !has_bash() {
+        return;
+    }
+
+    println!("bash: syncing ...");
+
+    let it_path = utils::env::home_dir().join(".bash_it");
+    if !utils::git::path_is_git_repository(&it_path) {
+        utils::fs::delete_if_exists(&it_path);
+        let it_url = "https://github.com/Bash-it/bash-it.git";
+        match utils::git::shallow_clone(it_url, &it_path.to_string_lossy()) {
+            Ok(()) => {}
+            Err(error) => println!("bash: unable to install bash-it: {}", error),
+        }
+    }
+
+    match utils::process::command_spawn_wait(
+        "bash",
+        &[
+            utils::env::home_dir()
+                .join(".bash_it/install.sh")
+                .to_string_lossy()
+                .as_ref(),
+            "--silent",
+            "--no-modify-config",
+        ],
+    ) {
+        Ok(_status) => {}
+        Err(error) => println!("bash: unable to run bash-it installer: {}", error),
+    }
+
+    // TODO: deprecated, deleted this later
+    utils::fs::symbolic_link_if_exists(
+        utils::env::home_dir().join(".dotfiles/inputrc"),
+        utils::env::home_dir().join(".inputrc"),
+    );
+    utils::fs::symbolic_link_if_exists(
+        utils::env::home_dir().join(".dotfiles/profile"),
+        utils::env::home_dir().join(".profile"),
+    );
+    utils::fs::symbolic_link_if_exists(
+        utils::env::home_dir().join(".dotfiles/bashrc"),
+        utils::env::home_dir().join(".bashrc"),
+    );
+
+    utils::fs::symbolic_link_if_exists(
+        utils::env::home_dir().join(".dotfiles/config/inputrc"),
+        utils::env::home_dir().join(".inputrc"),
+    );
+    utils::fs::symbolic_link_if_exists(
+        utils::env::home_dir().join(".dotfiles/config/profile"),
+        utils::env::home_dir().join(".profile"),
+    );
+    utils::fs::symbolic_link_if_exists(
+        utils::env::home_dir().join(".dotfiles/config/bashrc"),
+        utils::env::home_dir().join(".bashrc"),
+    );
+}
+
+pub fn update() {
+    if !has_bash() {
+        return;
+    }
+
+    println!("bash: updating ...");
+
+    let it_path = utils::env::home_dir().join(".bash_it");
+    if utils::git::path_is_git_repository(&it_path) {
+        match utils::git::shallow_fetch(it_path.to_string_lossy()) {
+            Ok(()) => {}
+            Err(error) => println!("bash: unable to update bash-it: {}", error),
+        }
+    }
+}
+
+fn has_bash() -> bool {
+    match utils::process::command_output("bash", &["--version"]) {
+        Ok(output) => output.status.success(),
+        Err(_error) => {
+            false // bash probably not installed
+        }
+    }
+}

--- a/src/tasks/minikube.rs
+++ b/src/tasks/minikube.rs
@@ -35,8 +35,20 @@ fn asset_filter(asset: &Asset) -> bool {
 fn trim_version(stdout: String) -> String {
     let line = stdout.lines().next().unwrap_or_default();
     let parts: Vec<&str> = line.splitn(2, ':').collect();
-    if parts.len() < 2 {
+    if parts.len() == 2 {
         return String::from(parts[1].trim());
     }
     String::from("unexpected")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trim_version_output() {
+        let stdout = String::from("minikube version: v0.28.2\n");
+        let got = trim_version(stdout);
+        assert_eq!(got, String::from("v0.28.2"));
+    }
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,5 +1,6 @@
 mod alacritty;
 mod atom;
+mod bash;
 mod dep;
 mod dotfiles;
 mod git;
@@ -33,6 +34,7 @@ pub fn sync() {
 
     alacritty::sync();
     atom::sync();
+    bash::sync();
     dep::sync();
     git::sync();
     gitleaks::sync();
@@ -66,6 +68,7 @@ pub fn update() {
 
     alacritty::update();
     atom::update();
+    bash::update();
     dep::update();
     git::update();
     gitleaks::update();

--- a/src/tasks/zsh.rs
+++ b/src/tasks/zsh.rs
@@ -81,7 +81,7 @@ pub fn update() {
 }
 
 fn has_zsh() -> bool {
-    match utils::process::command_output("zsh", &["-V"]) {
+    match utils::process::command_output("zsh", &["--version"]) {
         Ok(output) => output.status.success(),
         Err(_error) => {
             false // zsh probably not installed


### PR DESCRIPTION
### Added
 - bash: keep [bash-it](https://github.com/Bash-it/bash-it) `sync`ed and `update`d

### Fixed
 - minikube: parse `minikube version` output better
