### PR TITLE
ssh: properly parse `Hostname` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- ssh: properly parse and honour the `Hostname` directive in SSH settings
+
 ## [0.20.0] - 2018-10-09
 
 ### Added

--- a/tests/fixtures/ssh_config.input.txt
+++ b/tests/fixtures/ssh_config.input.txt
@@ -5,9 +5,11 @@ VisualHostKey yes
 
 # comment
 Host foo
+  Hostname foo.example
   Ciphers aes128-ctr,aes192-ctr,aes256-ctr
 
 Host bar
+  Hostname bar.example
   IdentityFile ~/.ssh/id_rsa
 
 # comment

--- a/tests/fixtures/ssh_config.output.txt
+++ b/tests/fixtures/ssh_config.output.txt
@@ -3,10 +3,12 @@ ConnectTimeout 10
 VisualHostKey yes
 
 Host bar
+  Hostname bar.example
   IdentityFile ~/.ssh/id_rsa
 
 Host foo
   Ciphers aes128-ctr,aes192-ctr,aes256-ctr
+  Hostname foo.example
 
 Match exec true
   EscapeChar %


### PR DESCRIPTION
### Fixed
 - ssh: properly parse and honour the `Hostname` directive in SSH settings (fixes #125)