### PR TITLE
keep bazel `sync`ed and `update`d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- bazel: keep [bazel](https://github.com/bazelbuild/bazel) `sync`ed and `update`d
+
 ### Fixed
 
 - ssh: properly parse and honour the `Hostname` directive in SSH settings

--- a/src/tasks/bazel.rs
+++ b/src/tasks/bazel.rs
@@ -1,0 +1,47 @@
+use std::env::consts::ARCH;
+
+use regex::Regex;
+
+use lib::ghrtask::GHRTask;
+use utils::github::Asset;
+use utils::golang::os;
+
+pub fn sync() {
+    match GHR_TASK.sync() {
+        _ => {}
+    }
+}
+
+pub fn update() {
+    match GHR_TASK.update() {
+        _ => {}
+    }
+}
+
+const GHR_TASK: GHRTask = GHRTask {
+    asset_filter,
+    #[cfg(windows)]
+    command: "bazel.exe",
+    #[cfg(not(windows))]
+    command: "bazel",
+    repo: ("bazelbuild", "bazel"),
+    trim_version,
+    version_arg: "version",
+};
+
+fn asset_filter(asset: &Asset) -> bool {
+    let re = Regex::new(&format!("^bazel-.*-{}-{}(\\.exe)?$", os(), ARCH)).unwrap();
+
+    re.is_match(&asset.name)
+}
+
+#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
+fn trim_version(stdout: String) -> String {
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.splitn(2, ':').collect();
+        if parts[0].trim() == "Build label" {
+            return String::from(parts[1].trim());
+        }
+    }
+    String::from("unexpected")
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -8,6 +8,7 @@ use lib::{
 mod alacritty;
 mod atom;
 mod bash;
+mod bazel;
 mod dep;
 mod dotfiles;
 mod git;
@@ -55,6 +56,7 @@ pub fn sync() {
     }
 
     atom::sync();
+    bazel::sync();
     dep::sync();
     git::sync();
     gitleaks::sync();
@@ -92,6 +94,7 @@ pub fn update() {
     }
 
     atom::update();
+    bazel::update();
     dep::update();
     git::update();
     gitleaks::update();


### PR DESCRIPTION
### Added
 - bazel: keep [bazel](https://github.com/bazelbuild/bazel) `sync`ed and `update`d (fixes #126)