### PR TITLE
Decompose rust tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - rust: extract out separate "rustup" task
 
+- rust: extract out separate "rustc" task
+
 ## [0.22.2] - 2018-11-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- goget: no longer run `gometalinter --install`
+
 ## [0.22.2] - 2018-11-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - goget: no longer run `gometalinter --install`
 
+- rust: extract out separate "rustup" task
+
 ## [0.22.2] - 2018-11-13
 
 ### Changed

--- a/src/lib/rust.rs
+++ b/src/lib/rust.rs
@@ -20,6 +20,19 @@ where
     command_spawn_wait(rustup_exe(), args).map(|_| ())
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
+pub fn rustup_output<S>(args: &[S]) -> io::Result<String>
+where
+    S: Into<String> + AsRef<str>,
+{
+    let output = command_output(rustup_exe(), args)?;
+    Ok(format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout).trim(),
+        String::from_utf8_lossy(&output.stderr).trim(),
+    ).to_string())
+}
+
 pub fn rustup_version() -> String {
     match command_output(rustup_exe(), &["--version"]) {
         Ok(output) => String::from_utf8_lossy(&output.stdout).trim().to_string(),

--- a/src/lib/rust.rs
+++ b/src/lib/rust.rs
@@ -1,0 +1,37 @@
+use std::{io, path::PathBuf};
+
+use utils::{
+    env::home_dir,
+    process::{command_output, command_spawn_wait},
+};
+
+pub fn has_rustup() -> bool {
+    match command_output(rustup_exe(), &["--version"]) {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
+pub fn rustup<S>(args: &[S]) -> io::Result<()>
+where
+    S: Into<String> + AsRef<str>,
+{
+    command_spawn_wait(rustup_exe(), args).map(|_| ())
+}
+
+pub fn rustup_version() -> String {
+    match command_output(rustup_exe(), &["--version"]) {
+        Ok(output) => String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        Err(_) => String::new(),
+    }
+}
+
+fn rustup_exe() -> PathBuf {
+    #[cfg(windows)]
+    let pb = home_dir().join(".cargo\\bin\\rustup.exe");
+    #[cfg(not(windows))]
+    let pb = home_dir().join(".cargo/bin/rustup");
+
+    pb
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod lib {
     pub mod ghratask;
     pub mod ghrtask;
     pub mod python;
+    pub mod rust;
     pub mod task;
     pub mod version;
 }

--- a/src/tasks/goget.rs
+++ b/src/tasks/goget.rs
@@ -89,12 +89,6 @@ fn sync() -> task::Result {
         println!("warning: goget: unable to install packages: {}", error);
     };
 
-    if which::which("gometalinter").is_ok() {
-        if let Err(error) = utils::process::command_spawn_wait("gometalinter", &["--install"]) {
-            println!("warning: goget: unable to install linters: {}", error);
-        };
-    };
-
     Ok(Status::Done)
 }
 
@@ -110,14 +104,6 @@ fn update() -> task::Result {
 
     if let Err(error) = utils::process::command_spawn_wait("go", &install_args) {
         println!("warning: goget: unable to update packages: {}", error);
-    };
-
-    if which::which("gometalinter").is_ok() {
-        if let Err(error) =
-            utils::process::command_spawn_wait("gometalinter", &["--install", "--force"])
-        {
-            println!("warning: goget: unable to update linters: {}", error);
-        };
     };
 
     Ok(Status::Changed(

--- a/src/tasks/goget.rs
+++ b/src/tasks/goget.rs
@@ -1,7 +1,6 @@
 use std::fs;
 
 use toml;
-use which;
 
 use lib::task::{self, Status, Task};
 use utils;

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -27,6 +27,7 @@ mod nodejs;
 mod npm;
 mod psql;
 mod rust;
+mod rustc;
 mod rustup;
 mod shfmt;
 mod skaffold;
@@ -92,7 +93,7 @@ fn ghr_tasks() -> Vec<Task> {
 }
 
 fn rust_tasks() -> Vec<Task> {
-    vec![rustup::task(), rust::task()]
+    vec![rustup::task(), rustc::task(), rust::task()]
 }
 
 fn tasks() -> Vec<Task> {

--- a/src/tasks/rust.rs
+++ b/src/tasks/rust.rs
@@ -166,12 +166,6 @@ fn sync() -> task::Result {
 }
 
 fn update() -> task::Result {
-    if !rust::has_rustup() {
-        return Ok(Status::Skipped);
-    }
-
-    rust::rustup(&["update", "stable"]).expect(ERROR_MSG);
-
     if !has_cargo() {
         return Ok(Status::Done);
     }

--- a/src/tasks/rustc.rs
+++ b/src/tasks/rustc.rs
@@ -1,0 +1,48 @@
+use regex;
+
+use lib::{
+    rust,
+    task::{self, Status, Task},
+};
+
+#[derive(Debug, Deserialize)]
+struct Config {
+    install: Vec<String>,
+}
+
+const TOOLCHAINS: &[&str] = &["stable", "nightly"];
+
+pub fn task() -> Task {
+    Task {
+        name: "rustc".to_string(),
+        sync,
+        update,
+    }
+}
+
+fn sync() -> task::Result {
+    if !rust::has_rustup() {
+        return Ok(Status::Skipped);
+    }
+
+    let toolchains = rust::rustup_output(&["toolchain", "list"])?;
+
+    for t in TOOLCHAINS {
+        let re = regex::Regex::new(&format!("^{}-", t)).unwrap();
+        if !re.is_match(&toolchains) {
+            rust::rustup(&["toolchain", "install", t])?;
+        }
+    }
+
+    Ok(Status::Done)
+}
+
+fn update() -> task::Result {
+    if !rust::has_rustup() {
+        return Ok(Status::Skipped);
+    }
+
+    rust::rustup(&["update"])?;
+
+    Ok(Status::Done)
+}

--- a/src/tasks/rustup.rs
+++ b/src/tasks/rustup.rs
@@ -1,0 +1,44 @@
+use lib::{
+    rust,
+    task::{self, Status, Task},
+};
+
+#[derive(Debug, Deserialize)]
+struct Config {
+    install: Vec<String>,
+}
+
+pub fn task() -> Task {
+    Task {
+        name: "rustup".to_string(),
+        sync,
+        update,
+    }
+}
+
+fn sync() -> task::Result {
+    if rust::has_rustup() {
+        Ok(Status::NoChange(rust::rustup_version()))
+    } else {
+        // TODO: automate installation from https://rustup.rs
+        Ok(Status::Skipped)
+    }
+}
+
+fn update() -> task::Result {
+    if !rust::has_rustup() {
+        return Ok(Status::Skipped);
+    }
+
+    let current = rust::rustup_version();
+
+    rust::rustup(&["self", "update"])?;
+
+    let latest = rust::rustup_version();
+
+    if current == latest {
+        Ok(Status::NoChange(current))
+    } else {
+        Ok(Status::Changed(current, latest))
+    }
+}


### PR DESCRIPTION
### Changed
 - goget: no longer run `gometalinter --install`
 - rust: extract out separate "rustup" task
 - rust: extract out separate "rustc" task
