### PR TITLE
Use env for child processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- local: new task; add "~/.local/bin" to PATH given by `env` command
+
 ### Changed
 
 - goget: no longer run `gometalinter --install`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - rust: extract out separate "rustc" task
 
+- use values from `env` command for child processes
+
 ### Fixed
 
 - ssh: support "TIME FORMAT" values besides raw integers (seconds)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - goget: no longer run `gometalinter --install`
 
+- golang, nodejs, rustup: modify PATH given by `env` command
+
 - rust: extract out separate "rustup" task
 
 - rust: extract out separate "rustc" task

--- a/src/lib/rust.rs
+++ b/src/lib/rust.rs
@@ -5,6 +5,10 @@ use utils::{
     process::{command_output, command_spawn_wait},
 };
 
+pub fn bin_dir() -> PathBuf {
+    home_dir().join(".cargo").join("bin")
+}
+
 pub fn has_rustup() -> bool {
     match command_output(rustup_exe(), &["--version"]) {
         Ok(_) => true,
@@ -42,9 +46,9 @@ pub fn rustup_version() -> String {
 
 fn rustup_exe() -> PathBuf {
     #[cfg(windows)]
-    let pb = home_dir().join(".cargo\\bin\\rustup.exe");
+    let pb = bin_dir().join("rustup.exe");
     #[cfg(not(windows))]
-    let pb = home_dir().join(".cargo/bin/rustup");
+    let pb = bin_dir().join("rustup");
 
     pb
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,8 @@ extern crate toml;
 extern crate which;
 extern crate zip;
 
+use std::env::var;
+
 use clap::{App, SubCommand};
 
 mod lib {
@@ -42,6 +44,8 @@ mod utils {
     pub mod ssh;
 }
 
+use lib::env::Shell;
+
 fn main() {
     let matches = App::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
@@ -58,7 +62,9 @@ fn main() {
     }
 
     if let Some(_matches) = matches.subcommand_matches("env") {
-        tasks::env();
+        let exports = tasks::env();
+        let shell = var("SHELL").unwrap_or_default();
+        println!("{}", exports.to_shell(Shell::from(shell.as_str())));
         return;
     }
 }

--- a/src/tasks/golang.rs
+++ b/src/tasks/golang.rs
@@ -1,9 +1,22 @@
-use lib::task::{self, Status, Task};
+use lib::{
+    env::Exports,
+    task::{self, Status, Task},
+};
 use utils::{
     self,
     fs::mktemp,
-    golang::{arch, os},
+    golang::{arch, bin_dir, os},
 };
+
+pub fn env(mut exports: Exports) -> Exports {
+    let dir = bin_dir();
+    if !exports.path.contains(&dir) {
+        let mut paths = vec![dir];
+        exports.path.append(&mut paths);
+        exports.path = paths;
+    }
+    exports
+}
 
 pub fn task() -> Task {
     Task {

--- a/src/tasks/golang.rs
+++ b/src/tasks/golang.rs
@@ -12,7 +12,7 @@ pub fn env(mut exports: Exports) -> Exports {
     let dir = bin_dir();
     if !exports.path.contains(&dir) {
         let mut paths = vec![dir];
-        exports.path.append(&mut paths);
+        paths.append(&mut exports.path);
         exports.path = paths;
     }
     exports

--- a/src/tasks/local.rs
+++ b/src/tasks/local.rs
@@ -1,0 +1,12 @@
+use lib::env::Exports;
+use utils::env::home_dir;
+
+pub fn env(mut exports: Exports) -> Exports {
+    let dir = home_dir().join(".local").join("bin");
+    if !exports.path.contains(&dir) {
+        let mut paths = vec![dir];
+        paths.append(&mut exports.path);
+        exports.path = paths;
+    }
+    exports
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -17,6 +17,7 @@ mod golang;
 mod hadolint;
 mod hyper;
 mod jq;
+mod local;
 #[cfg(target_os = "macos")]
 mod macos;
 mod minikube;
@@ -41,6 +42,7 @@ mod zsh;
 pub fn env() -> Exports {
     let mut exports: Exports = Default::default();
     exports = golang::env(exports);
+    exports = local::env(exports);
     exports = nodejs::env(exports);
     exports = rustup::env(exports);
     exports = vim::env(exports);

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,9 +1,6 @@
-use std::{env::var, path::PathBuf, thread};
+use std::{path::PathBuf, thread};
 
-use lib::{
-    env::{Exports, Shell},
-    task::Task,
-};
+use lib::{env::Exports, task::Task};
 
 mod alacritty;
 mod atlantis;
@@ -41,14 +38,12 @@ mod windows;
 mod yq;
 mod zsh;
 
-pub fn env() {
-    let mut exports = Exports {
+pub fn env() -> Exports {
+    let exports = Exports {
         editor: PathBuf::new(),
         path: Vec::<PathBuf>::new(),
     };
-    exports = vim::env(exports);
-    let shell = var("SHELL").unwrap_or_default();
-    println!("{}", exports.to_shell(Shell::from(shell.as_str())));
+    vim::env(exports)
 }
 
 pub fn all() {

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, thread};
+use std::thread;
 
 use lib::{env::Exports, task::Task};
 
@@ -39,11 +39,12 @@ mod yq;
 mod zsh;
 
 pub fn env() -> Exports {
-    let exports = Exports {
-        editor: PathBuf::new(),
-        path: Vec::<PathBuf>::new(),
-    };
-    vim::env(exports)
+    let mut exports: Exports = Default::default();
+    exports = golang::env(exports);
+    exports = nodejs::env(exports);
+    exports = rustup::env(exports);
+    exports = vim::env(exports);
+    exports
 }
 
 pub fn all() {

--- a/src/tasks/nodejs.rs
+++ b/src/tasks/nodejs.rs
@@ -1,11 +1,24 @@
 use std::{self, io, str};
 
-use lib::task::{self, Status, Task};
+use lib::{
+    env::Exports,
+    task::{self, Status, Task},
+};
 use utils::{
     self,
     fs::mktemp,
-    nodejs::{arch, os},
+    nodejs::{arch, bin_dir, os},
 };
+
+pub fn env(mut exports: Exports) -> Exports {
+    let dir = bin_dir();
+    if !exports.path.contains(&dir) {
+        let mut paths = vec![dir];
+        exports.path.append(&mut paths);
+        exports.path = paths;
+    }
+    exports
+}
 
 pub fn task() -> Task {
     Task {

--- a/src/tasks/nodejs.rs
+++ b/src/tasks/nodejs.rs
@@ -14,7 +14,7 @@ pub fn env(mut exports: Exports) -> Exports {
     let dir = bin_dir();
     if !exports.path.contains(&dir) {
         let mut paths = vec![dir];
-        exports.path.append(&mut paths);
+        paths.append(&mut exports.path);
         exports.path = paths;
     }
     exports

--- a/src/tasks/rustup.rs
+++ b/src/tasks/rustup.rs
@@ -1,4 +1,5 @@
 use lib::{
+    env::Exports,
     rust,
     task::{self, Status, Task},
 };
@@ -6,6 +7,16 @@ use lib::{
 #[derive(Debug, Deserialize)]
 struct Config {
     install: Vec<String>,
+}
+
+pub fn env(mut exports: Exports) -> Exports {
+    let dir = rust::bin_dir();
+    if !exports.path.contains(&dir) {
+        let mut paths = vec![dir];
+        paths.append(&mut exports.path);
+        exports.path = paths;
+    }
+    exports
 }
 
 pub fn task() -> Task {

--- a/src/utils/golang.rs
+++ b/src/utils/golang.rs
@@ -15,6 +15,10 @@ pub fn arch() -> &'static str {
     }
 }
 
+pub fn bin_dir() -> PathBuf {
+    install_path().join("bin")
+}
+
 pub fn current_version() -> String {
     #[cfg(windows)]
     let exe_path = install_path().join("bin").join("go.exe");
@@ -32,15 +36,11 @@ pub fn current_version() -> String {
     }
 }
 
-fn install_path() -> PathBuf {
-    utils::env::home_dir().join(".local").join("go")
-}
-
 pub fn is_installed() -> bool {
     #[cfg(windows)]
-    let exe_path = install_path().join("bin").join("go.exe");
+    let exe_path = bin_dir().join("go.exe");
     #[cfg(not(windows))]
-    let exe_path = install_path().join("bin").join("go");
+    let exe_path = bin_dir().join("go");
 
     exe_path.is_file()
 }
@@ -74,6 +74,10 @@ pub fn os() -> &'static str {
     } else {
         OS
     }
+}
+
+fn install_path() -> PathBuf {
+    utils::env::home_dir().join(".local").join("go")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Added
 - local: new task; add "~/.local/bin" to PATH given by `env` command
 ### Changed
 - golang, nodejs, rustup: modify PATH given by `env` command
 - use values from `env` command for child processes