### PR TITLE
golang: properly avoid non-stable versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- golang: properly avoid non-stable versions of `go`
+
 ## [0.26.1] - 2018-12-12
 
 ### Fixed

--- a/src/lib/version.rs
+++ b/src/lib/version.rs
@@ -1,13 +1,17 @@
 use regex;
 
-const UNSTABLE: &[&str] = &["alpha", "beta", "canary", "dev", "rc"];
+const UNSTABLE: &[&str] = &["alpha", "beta", "canary", "dev", "preview", "rc"];
 
 #[allow(clippy::needless_pass_by_value)]
 pub fn is_stable<S>(version: S) -> bool
 where
     S: Into<String> + AsRef<str>,
 {
-    let re = regex::Regex::new(&format!("\\b({})\\b", UNSTABLE.join("|"))).unwrap();
+    let re = regex::Regex::new(&format!(
+        "(\\b|[[:^alpha:]])({})(\\b|[[:^alpha:]])",
+        UNSTABLE.join("|")
+    ))
+    .unwrap();
     !re.is_match(version.as_ref())
 }
 
@@ -22,5 +26,6 @@ mod tests {
 
         assert!(!is_stable("1.0.0-alpha.1"));
         assert!(!is_stable("1.0.0-beta.1"));
+        assert!(!is_stable("go1.12beta1"));
     }
 }


### PR DESCRIPTION
### Fixed

- golang: properly avoid non-stable versions of `go`