### PR TITLE
pkg: brew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- little bit less concurrency for now
+
 - less output when there aren't any errors
 
 ## [0.26.2] - 2018-12-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- brew: `env` exports PATH including [Homebrew](https://brew.sh) if found
+
 ### Changed
 
 - less output when there aren't any errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - brew: `env` exports PATH including [Homebrew](https://brew.sh) if found
 
+- brew: keep [Homebrew](https://brew.sh) `sync`ed and `update`d (does not automatically install Homebrew yet)
+
 ### Changed
 
 - less output when there aren't any errors

--- a/src/lib/brew.rs
+++ b/src/lib/brew.rs
@@ -1,0 +1,85 @@
+use std::{
+    env, io,
+    path::PathBuf,
+    str,
+};
+
+use dirs;
+use which::{self, which_in};
+
+use crate::utils::process::{command_output, command_spawn_wait};
+
+const INSTALL_DIRS: &[&str] = &["/usr/local", "/home/linuxbrew/.linuxbrew", "~/.linuxbrew"];
+
+pub fn has_brew() -> bool {
+    match brew_exe() {
+        Some(exe) => match command_output(exe, &["--version"]) {
+            Ok(_) => true,
+            Err(_) => false,
+        },
+        None => false,
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub fn brew<S>(args: &[S]) -> io::Result<()>
+where
+    S: Into<String> + AsRef<str>,
+{
+    match brew_exe() {
+        Some(exe) => command_spawn_wait(exe, args).map(|_| ()),
+        None => Err(io::Error::new(io::ErrorKind::NotFound, "brew")),
+    }
+}
+
+pub fn brew_exe() -> Option<PathBuf> {
+    let home_dir = dirs::home_dir().expect("brew: no $HOME");
+    let bin_dirs: Vec<PathBuf> = INSTALL_DIRS
+        .iter()
+        .map(|dir| {
+            PathBuf::from(if dir.starts_with("~/") {
+                dir.replace("~", &home_dir.to_string_lossy())
+            } else {
+                dir.to_string()
+            })
+            .join("bin")
+        })
+        .collect();
+    match which_in(
+        "brew",
+        Some(env::join_paths(bin_dirs).expect("brew: bad INSTALL_DIRS")),
+        env::current_dir().expect("brew: no $PWD"),
+    ) {
+        Ok(p) => Some(p),
+        Err(_) => None,
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub fn brew_output<S>(args: &[S]) -> io::Result<String>
+where
+    S: Into<String> + AsRef<str>,
+{
+    match brew_exe() {
+        Some(exe) => {
+            let output = command_output(exe, args)?;
+            Ok(format!(
+                "{}\n{}",
+                String::from_utf8_lossy(&output.stdout).trim(),
+                String::from_utf8_lossy(&output.stderr).trim(),
+            )
+            .to_string())
+        }
+        None => Err(io::Error::new(io::ErrorKind::NotFound, "brew")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn brew_exe_does_not_panic() {
+        brew_exe();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::env::var;
 use clap::{App, SubCommand};
 
 mod lib {
+    pub mod brew;
     pub mod cargo;
     pub mod env;
     pub mod favourites;

--- a/src/tasks/brew.rs
+++ b/src/tasks/brew.rs
@@ -1,9 +1,16 @@
 use std::{self, path::PathBuf};
 
-use crate::lib::{brew::brew_prefix, env::Exports};
+use crate::{
+    lib::{
+        brew,
+        env::Exports,
+        task::{self, Status, Task},
+    },
+    utils::fs,
+};
 
 pub fn env(mut exports: Exports) -> Exports {
-    match brew_prefix() {
+    match brew::brew_prefix() {
         Some(prefix) => {
             let mut paths: Vec<PathBuf> = vec!["bin", "sbin"]
                 .iter()
@@ -24,4 +31,53 @@ pub fn env(mut exports: Exports) -> Exports {
         None => {}
     }
     exports
+}
+
+pub fn task() -> Task {
+    Task {
+        name: "brew".to_string(),
+        sync,
+        update,
+    }
+}
+
+fn sync() -> task::Result {
+    if !brew::has_brew() {
+        return Ok(Status::Skipped);
+    }
+
+    brew::brew(&["cleanup"])?;
+
+    Ok(Status::Done)
+}
+
+fn update() -> task::Result {
+    if !brew::has_brew() {
+        return Ok(Status::Skipped);
+    }
+
+    let before = brew::brew_output(&["--version"])?;
+
+    // this may fail if a tap cannot be accessed,
+    // and this is fine, hence ignoring this error
+    brew::brew(&["update"]).unwrap_or(());
+
+    brew::brew(&["upgrade"])?;
+
+    // can't get here otherwise, so this `.expect()` is fine
+    let prefix = brew::brew_prefix().expect("no $HOMEBREW_PREFIX");
+
+    // zsh complains if certains paths are not secure enough
+    // chmod g-w /usr/local/share/zsh /usr/local/share/zsh/site-functions
+    fs::set_executable(prefix.join("share/zsh"))?;
+    fs::set_executable(prefix.join("share/zsh/site-functions"))?;
+
+    let after = brew::brew_output(&["--version"])?;
+
+    if before == after {
+        Ok(Status::NoChange(before))
+    } else {
+        Ok(Status::Changed(before, after))
+    }
+    // TODO: separate task/status for packages
 }

--- a/src/tasks/brew.rs
+++ b/src/tasks/brew.rs
@@ -1,20 +1,14 @@
 use std::{self, path::PathBuf};
 
-use crate::lib::{brew::brew_exe, env::Exports};
+use crate::lib::{brew::brew_prefix, env::Exports};
 
 pub fn env(mut exports: Exports) -> Exports {
-    match brew_exe() {
-        Some(exe) => {
-            // these `.expect()`s are fine, we trust `brew_exe()`
-            let install_dir = exe
-                .parent()
-                .expect("brew: no ..")
-                .parent()
-                .expect("brew: no ..");
+    match brew_prefix() {
+        Some(prefix) => {
             let mut paths: Vec<PathBuf> = vec!["bin", "sbin"]
                 .iter()
                 .filter_map(|b| {
-                    let dir = install_dir.join(b);
+                    let dir = prefix.join(b);
                     if exports.path.contains(&dir) {
                         None
                     } else {

--- a/src/tasks/brew.rs
+++ b/src/tasks/brew.rs
@@ -1,0 +1,33 @@
+use std::{self, path::PathBuf};
+
+use crate::lib::{brew::brew_exe, env::Exports};
+
+pub fn env(mut exports: Exports) -> Exports {
+    match brew_exe() {
+        Some(exe) => {
+            // these `.expect()`s are fine, we trust `brew_exe()`
+            let install_dir = exe
+                .parent()
+                .expect("brew: no ..")
+                .parent()
+                .expect("brew: no ..");
+            let mut paths: Vec<PathBuf> = vec!["bin", "sbin"]
+                .iter()
+                .filter_map(|b| {
+                    let dir = install_dir.join(b);
+                    if exports.path.contains(&dir) {
+                        None
+                    } else {
+                        Some(dir)
+                    }
+                })
+                .collect();
+            paths.append(&mut exports.path);
+            exports.path = paths;
+
+            // TODO: parse and export the output from `brew shellenv`
+        }
+        None => {}
+    }
+    exports
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -122,7 +122,11 @@ fn nodejs_tasks() -> Vec<Task> {
 }
 
 fn rust_tasks() -> Vec<Task> {
-    vec![rustup::task(), rustc::task(), rust::task()]
+    vec![
+        rustup::task(),
+        rustc::task(), // deps: rustup
+        rust::task(),  // deps: rustc
+    ]
 }
 
 fn tasks() -> Vec<Task> {
@@ -130,7 +134,8 @@ fn tasks() -> Vec<Task> {
         alacritty::task(), // deps: config
         atom::task(),
         bash::task(), // deps: config
-        git::task(),  // deps: nodejs/npm
+        brew::task(),
+        git::task(), // deps: nodejs/npm
         googlecloudsdk::task(),
         hyper::task(), // deps: config
         macos::task(),

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -52,13 +52,17 @@ pub fn env() -> Exports {
 }
 
 pub fn all() {
+    // resource utilisation goals:
+    // - distinguish CPU-heavy from I/O-heavy tasks
+    // - run a CPU-heavy task concurrently with an I/O-heavy task
+    // - serialise tasks of the same type to avoid clogging pipes
+    // TODO: realise these goals :)
+    // TODO: maybe queue I/O within GitHub and HTTP helpers
+
     dotfiles::task().sync_then_update(); // provides: config; must be first
 
-    let ghr_handle = thread::spawn(|| {
-        for t in ghr_tasks() {
-            t.sync_then_update();
-        }
-    });
+    // split out tasks that may involve compilation,
+    // so we might be able to download at the same time
 
     let golang_handle = thread::spawn(|| {
         for t in golang_tasks() {
@@ -78,7 +82,6 @@ pub fn all() {
         }
     });
 
-    ghr_handle.join().unwrap();
     golang_handle.join().unwrap();
     nodejs_handle.join().unwrap();
     rust_handle.join().unwrap();
@@ -88,23 +91,6 @@ pub fn all() {
     for t in tasks() {
         t.sync_then_update();
     }
-}
-
-fn ghr_tasks() -> Vec<Task> {
-    vec![
-        atlantis::task(),
-        bazel::task(),
-        dep::task(),
-        gitleaks::task(),
-        gitsizer::task(),
-        hadolint::task(),
-        jq::task(),
-        minikube::task(),
-        shfmt::task(),
-        skaffold::task(),
-        vale::task(),
-        yq::task(),
-    ]
 }
 
 fn golang_tasks() -> Vec<Task> {
@@ -131,6 +117,21 @@ fn rust_tasks() -> Vec<Task> {
 
 fn tasks() -> Vec<Task> {
     vec![
+        // these are GitHub Release tasks,
+        // that are mostly I/O-heavy,
+        // and serialising such things avoids clogging our pipes
+        atlantis::task(),
+        bazel::task(),
+        dep::task(),
+        gitleaks::task(),
+        gitsizer::task(),
+        hadolint::task(),
+        jq::task(),
+        minikube::task(),
+        shfmt::task(),
+        skaffold::task(),
+        vale::task(),
+        yq::task(),
         alacritty::task(), // deps: config
         atom::task(),
         bash::task(), // deps: config

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -7,6 +7,7 @@ mod atlantis;
 mod atom;
 mod bash;
 mod bazel;
+mod brew;
 mod dep;
 mod dotfiles;
 mod git;
@@ -40,6 +41,7 @@ mod zsh;
 
 pub fn env() -> Exports {
     let mut exports: Exports = Default::default();
+    exports = brew::env(exports);
     exports = golang::env(exports);
     exports = googlecloudsdk::env(exports);
     exports = local::env(exports);


### PR DESCRIPTION
### Added

- brew: `env` exports PATH including [Homebrew](https://brew.sh) if found

- brew: keep [Homebrew](https://brew.sh) `sync`ed and `update`d (does not automatically install Homebrew yet)

### Changed

- little bit less concurrency for now