### PR TITLE
golang: `env` exports GOPATH and GOROOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- golang: `env` exports GOROOT and GOPATH when found
+
 ## [0.27.0] - 2019-02-02
 
 ### Added

--- a/src/tasks/golang.rs
+++ b/src/tasks/golang.rs
@@ -7,10 +7,20 @@ use crate::lib::{
 use crate::utils::{
     self,
     fs::mkftemp,
-    golang::{arch, bin_dir, os},
+    golang::{arch, bin_dir, gopath, goroot, os},
 };
 
 pub fn env(mut exports: Exports) -> Exports {
+    let gp = gopath();
+    if gp.is_dir() {
+        exports.gopath = gp;
+    }
+
+    let gr = goroot();
+    if gr.is_dir() {
+        exports.goroot = gr;
+    }
+
     let dir = bin_dir();
     if !exports.path.contains(&dir) {
         let mut paths = vec![dir];


### PR DESCRIPTION
### Added

- golang: `env` exports GOROOT and GOPATH when found