### PR TITLE
rustc: no "nightly" toolchain by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - git: synchronise settings from ~/.dotfiles/config/git.toml
 
+### Removed
+
+- rustc: no longer install "nightly" toolchain by default
+
 ## [0.28.0] - 2019-03-05
 
 ### Added

--- a/src/tasks/rustc.rs
+++ b/src/tasks/rustc.rs
@@ -5,7 +5,7 @@ use crate::lib::{
     task::{self, Status, Task},
 };
 
-const TOOLCHAINS: &[&str] = &["stable", "nightly"];
+const TOOLCHAINS: &[&str] = &["stable"];
 
 pub fn task() -> Task {
     Task {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -131,7 +131,7 @@ where
 pub fn mkdtemp() -> io::Result<PathBuf> {
     let temp_path;
     {
-        let mut temp = mktemp::Temp::new_dir()?;
+        let temp = mktemp::Temp::new_dir()?;
         temp_path = temp.to_path_buf();
         temp.release();
     }
@@ -141,7 +141,7 @@ pub fn mkdtemp() -> io::Result<PathBuf> {
 pub fn mkftemp() -> io::Result<PathBuf> {
     let temp_path;
     {
-        let mut temp = mktemp::Temp::new_file()?;
+        let temp = mktemp::Temp::new_file()?;
         temp_path = temp.to_path_buf();
         temp.release();
     }


### PR DESCRIPTION
### Removed

- rustc: no longer install "nightly" toolchain by default