### PR TITLE
publicsans: Public Sans `sync`ed and `update`d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- publicsans: keep [Public Sans (font)](https://github.com/uswds/public-sans) `sync`ed and `update`d
+
 ### Fixed
 
 - parse possible-`null` "name" in GitHub Releases (#213)

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -31,6 +31,7 @@ mod nodejs;
 mod npm;
 mod pip;
 mod psql;
+mod publicsans;
 mod rust;
 mod rustc;
 mod rustup;
@@ -102,6 +103,7 @@ fn sequence() -> Vec<String> {
         hack::task().name,
         hasklig::task().name,
         inter::task().name,
+        publicsans::task().name,
         fccache::task().name, // deps: all other font tasks
         // these are GitHub Release tasks,
         // that are mostly I/O-heavy,
@@ -166,6 +168,7 @@ fn mapping() -> HashMap<String, Task> {
     map.insert(String::from("npm"), npm::task());
     map.insert(String::from("pip"), pip::task());
     map.insert(String::from("psql"), psql::task());
+    map.insert(String::from("publicsans"), publicsans::task());
     map.insert(String::from("rust"), rust::task());
     map.insert(String::from("rustc"), rustc::task());
     map.insert(String::from("rustup"), rustup::task());

--- a/src/tasks/publicsans.rs
+++ b/src/tasks/publicsans.rs
@@ -1,0 +1,26 @@
+use crate::lib::{
+    ghrafont::GhraFont,
+    task::{self, Task},
+};
+
+pub fn task() -> Task {
+    Task {
+        name: String::from("publicsans"),
+        sync,
+        update,
+    }
+}
+
+const GHRA_FONT: GhraFont = GhraFont {
+    asset_re: r"^public-sans-.*\.zip$",
+    font_suffix: ".otf",
+    repo: ("uswds", "public-sans"),
+};
+
+fn sync() -> task::Result {
+    GHRA_FONT.sync()
+}
+
+fn update() -> task::Result {
+    GHRA_FONT.update()
+}


### PR DESCRIPTION
### Added

- publicsans: keep [Public Sans (font)](https://github.com/uswds/public-sans) `sync`ed and `update`d

- fixes #216 