### PR TITLE
brewbundle: run with `--verbose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- brewbundle: run with `--verbose` because otherwise it looks like it crashed
+
 ## [0.32.0] - 2019-05-28
 
 ### Added

--- a/src/tasks/brewbundle.rs
+++ b/src/tasks/brewbundle.rs
@@ -25,7 +25,7 @@ fn sync() -> task::Result {
     if check.exit_status.success() {
         return Ok(Status::NoChange(String::from("already installed")));
     }
-    brew::brew(&["bundle", "install", "--global", "--no-upgrade"])?;
+    brew::brew(&["bundle", "install", "--global", "--no-upgrade", "--verbose"])?;
     Ok(Status::Changed(
         String::from("unknown"),
         String::from("installed"),


### PR DESCRIPTION
### Fixed

- brewbundle: run with `--verbose` because otherwise it looks like it crashed