### PR TITLE
cascadiacode: `sync`/`update` font (fixes #294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- cascadiacode: keep [Cascadia Code (font)](https://github.com/microsoft/cascadia-code) `sync`ed and `update`d (#294)
+
 ## [0.33.0] - 2019-09-07
 
 ### Added

--- a/src/tasks/cascadiacode.rs
+++ b/src/tasks/cascadiacode.rs
@@ -1,0 +1,26 @@
+use crate::lib::{
+    ghrafont::GhraFont,
+    task::{self, Status, Task},
+};
+
+pub fn task() -> Task {
+    Task {
+        name: String::from("cascadiacode"),
+        sync,
+        update,
+    }
+}
+
+const GHRA_FONT: GhraFont = GhraFont {
+    asset_re: r"^Cascadia.ttf$",
+    font_suffix: ".ttf",
+    repo: ("microsoft", "cascadia-code"),
+};
+
+fn sync() -> task::Result {
+    GHRA_FONT.sync()
+}
+
+fn update(sync: Status) -> task::Result {
+    GHRA_FONT.update(sync)
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -11,6 +11,7 @@ mod bazel;
 mod brew;
 mod brewbundle;
 mod brewfile;
+mod cascadiacode;
 mod dep;
 mod dotfiles;
 mod fccache;
@@ -115,6 +116,7 @@ fn sequence() -> Vec<String> {
         rustc::task().name, // deps: rustup
         rust::task().name,  // deps: config,rustc
         // fonts
+        cascadiacode::task().name,
         fira::task().name,
         firacode::task().name,
         hack::task().name,
@@ -175,6 +177,7 @@ fn mapping() -> HashMap<String, Task> {
     map.insert(String::from("brew"), brew::task());
     map.insert(String::from("brewbundle"), brewbundle::task());
     map.insert(String::from("brewfile"), brewfile::task());
+    map.insert(String::from("cascadiacode"), cascadiacode::task());
     map.insert(String::from("dep"), dep::task());
     map.insert(String::from("dotfiles"), dotfiles::task());
     map.insert(String::from("fccache"), fccache::task());

--- a/src/utils/github.rs
+++ b/src/utils/github.rs
@@ -21,6 +21,16 @@ pub struct Asset {
     state: String,
     updated_at: String,
 }
+impl Asset {
+    pub fn new() -> Self {
+        Self {
+            browser_download_url: String::new(),
+            name: String::new(),
+            state: String::new(),
+            updated_at: String::new(),
+        }
+    }
+}
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Release {


### PR DESCRIPTION
### Added

- cascadiacode: keep [Cascadia Code (font)](https://github.com/microsoft/cascadia-code) `sync`ed and `update`d (fixes #294)