### PR TITLE
brew environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- env: append homebrew to PATH instead of prepending,
+  as we want to treat it more like a cross-distribution fallback,
+  rather than the primary source of packages (for now, at least)
+
 ## [0.37.0] - 2020-06-09
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `jokeyrhyme-dotfiles env` may now manipulate INFO_PATH and MAN_PATH
+
 ### Changed
 
 - env: append homebrew to PATH instead of prepending,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - `jokeyrhyme-dotfiles env` may now manipulate INFO_PATH and MAN_PATH
 
+- brew: append homebrew to INFO_PATH and MAN_PATH
+
 ### Changed
 
 - env: append homebrew to PATH instead of prepending,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   as we want to treat it more like a cross-distribution fallback,
   rather than the primary source of packages (for now, at least)
 
+- env: make GOPATH and GOROOT variables optional
+
 ## [0.37.0] - 2020-06-09
 
 ### Removed

--- a/src/lib/env.rs
+++ b/src/lib/env.rs
@@ -19,8 +19,8 @@ const PATH: &str = "PATH";
 #[derive(Debug)]
 pub struct Exports {
     pub editor: PathBuf,
-    pub gopath: PathBuf,
-    pub goroot: PathBuf,
+    pub gopath: Option<PathBuf>,
+    pub goroot: Option<PathBuf>,
     pub info_path: Vec<PathBuf>,
     pub man_path: Vec<PathBuf>,
     pub path: Vec<PathBuf>,
@@ -30,8 +30,8 @@ impl Exports {
     pub fn new() -> Exports {
         Exports {
             editor: PathBuf::new(),
-            gopath: PathBuf::new(),
-            goroot: PathBuf::new(),
+            gopath: None,
+            goroot: None,
             info_path: Vec::<PathBuf>::new(),
             man_path: Vec::<PathBuf>::new(),
             path: Vec::<PathBuf>::new(),
@@ -45,19 +45,23 @@ impl Exports {
             &self.editor.as_path().to_string_lossy().into_owned(),
         );
 
-        let gopath_line = export_shell(
-            &shell,
-            GOPATH,
-            &self.gopath.as_path().to_string_lossy().into_owned(),
-        );
+        let mut lines = vec![editor_line];
 
-        let goroot_line = export_shell(
-            &shell,
-            GOROOT,
-            &self.goroot.as_path().to_string_lossy().into_owned(),
-        );
+        if let Some(gopath) = &self.gopath {
+            lines.push(export_shell(
+                &shell,
+                GOPATH,
+                &gopath.as_path().to_string_lossy().into_owned(),
+            ));
+        }
 
-        let mut lines = vec![editor_line, gopath_line, goroot_line];
+        if let Some(goroot) = &self.goroot {
+            lines.push(export_shell(
+                &shell,
+                GOROOT,
+                &goroot.as_path().to_string_lossy().into_owned(),
+            ));
+        }
 
         if let Ok(paths) = join_paths(&self.info_path) {
             lines.push(export_shell(

--- a/src/tasks/brew.rs
+++ b/src/tasks/brew.rs
@@ -11,6 +11,15 @@ use crate::{
 
 pub fn env(mut exports: Exports) -> Exports {
     if let Some(prefix) = brew::brew_prefix() {
+        // TODO: consider parsing the output from `brew shellenv`
+
+        // we add homebrew to the end of ...PATH,
+        // as we want to treat it more like a cross-distribution fallback,
+        // rather than the primary source of packages (for now, at least)
+
+        exports.info_path.push(prefix.join("info"));
+        exports.man_path.push(prefix.join("man"));
+
         let mut paths: Vec<PathBuf> = vec!["bin", "sbin"]
             .iter()
             .filter_map(|b| {
@@ -22,13 +31,7 @@ pub fn env(mut exports: Exports) -> Exports {
                 }
             })
             .collect();
-
-        // we add homebrew to the end of PATH,
-        // as we want to treat it more like a cross-distribution fallback,
-        // rather than the primary source of packages (for now, at least)
         exports.path.append(&mut paths);
-
-        // TODO: parse and export the output from `brew shellenv`
     }
     exports
 }

--- a/src/tasks/brew.rs
+++ b/src/tasks/brew.rs
@@ -22,8 +22,11 @@ pub fn env(mut exports: Exports) -> Exports {
                 }
             })
             .collect();
-        paths.append(&mut exports.path);
-        exports.path = paths;
+
+        // we add homebrew to the end of PATH,
+        // as we want to treat it more like a cross-distribution fallback,
+        // rather than the primary source of packages (for now, at least)
+        exports.path.append(&mut paths);
 
         // TODO: parse and export the output from `brew shellenv`
     }

--- a/src/tasks/golang.rs
+++ b/src/tasks/golang.rs
@@ -13,12 +13,12 @@ use crate::utils::{
 pub fn env(mut exports: Exports) -> Exports {
     let gp = gopath();
     if gp.is_dir() {
-        exports.gopath = gp;
+        exports.gopath = Some(gp);
     }
 
     let gr = goroot();
     if gr.is_dir() {
-        exports.goroot = gr;
+        exports.goroot = Some(gr);
     }
 
     for dir in vec![bin_dir(), gopath().join("bin")] {


### PR DESCRIPTION
### Added

- `jokeyrhyme-dotfiles env` may now manipulate INFO_PATH and MAN_PATH

- brew: append homebrew to INFO_PATH and MAN_PATH

### Changed

- env: append homebrew to PATH instead of prepending,
  as we want to treat it more like a cross-distribution fallback,
  rather than the primary source of packages (for now, at least)

- env: make GOPATH and GOROOT variables optional